### PR TITLE
add ready listener type

### DIFF
--- a/doc/listeners.md
+++ b/doc/listeners.md
@@ -55,7 +55,7 @@ With these, the value returned from the listener is ignored.
 
 ## Debugging 
 
-Run `NODE_DEBUG=expressa node app.js` or `NODE_DEBUG=* app.js` to see what's going on in your app
+Run `DEBUG=expressa node --use-strict app.js` or `DEBUG=* --use-strict node app.js` to see what's going on in your app
 
 ## Async wrapper example 
 

--- a/validation_listeners.js
+++ b/validation_listeners.js
@@ -31,18 +31,6 @@ module.exports = function(api) {
 		}
 	});
 
-	collections = api.db.collection.all()
-		.then(function(result) {
-			result.forEach(function(collection) {
-				var schema = augmentSchema(collection.schema)
-				schemaValidators[collection._id] = ajv.compile(schema)
-			});
-			debug('validators loaded.')
-		}, function(err) {
-			console.error('failed to load collections');
-			console.error(err);
-		});
-
 	api.addListener('changed', function updateValidators(req, collection, data) {
 		if (collection == 'collection') {
 			var schema = augmentSchema(data.schema)
@@ -60,4 +48,16 @@ module.exports = function(api) {
 			return {code: 500, message: schemaValidators[collection].errors};
 		}
 	})
+
+	return api.db.collection.all()
+		.then(function(result) {
+			result.forEach(function(collection) {
+				var schema = augmentSchema(collection.schema)
+				schemaValidators[collection._id] = ajv.compile(schema)
+			});
+			debug('validators loaded.')
+		}, function(err) {
+			console.error('failed to load collections');
+			console.error(err);
+		});
 }


### PR DESCRIPTION
#28 I think a more generic solution of a listener when expressa is completely ready would be best. In this I've added another type to the current listener solution. What do you think?

In your app you can add the following and make any changes you want to db or other expressa stuff.

`expressa.addListener('ready', function() {
  console.log('Expressa ready');
});`