### PR TITLE
environment-based settings file 

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,9 @@ router.db = db
 
 router.settings = {}
 
-db.settings.get('production')
+process.env.NODE_ENV = process.env.NODE_ENV || "development"
+
+db.settings.get( process.env.NODE_ENV )
 	.then(function(data) {
 		router.settings = data;
 
@@ -55,7 +57,7 @@ db.settings.get('production')
 				console.error(err);
 			});
 	}, function(err) {
-		if (!fs.existsSync('data/settings/production.json')) {
+		if (!fs.existsSync('data/settings/'+process.env.NODE_ENV+'.json')) {
 		    console.error('Settings file does not exist.')
 		    console.error('Please visit the expressa admin page to run the installation process.')
 		    console.error('This is likely at http://localhost:3000/admin but may be different if you changed ports, etc.')

--- a/test/tests/collection.init.js
+++ b/test/tests/collection.init.js
@@ -29,9 +29,9 @@ util.test("create settings collection", function(next, error){
   })
 })
 
-util.test("create settings 'production'", function(next, error){
+util.test("create settings '"+process.env.NODE_ENV+"'", function(next, error){
   expressa.db.settings.create({
-    "_id": "production",
+    "_id": process.env.NODE_ENV,
     "postgresql_uri": "postgres://<username>:<password>@localhost/<database name>",
     "mongodb_uri": "mongodb://localhost:27017/test",
     "jwt_secret": "123123",


### PR DESCRIPTION
* using data/settings/{process.env.NODE_ENV}.json
* updated test

> WARNING: this can be a breaking change for people who only have data/settings/production.json in their existing expressa app (development.json is now default). Therefore I would suggest bumping the version from 0.2.12 -> 0.3.1