### PR TITLE
Single PG Pool

### DIFF
--- a/db/postgres.js
+++ b/db/postgres.js
@@ -6,7 +6,6 @@ module.exports = function (settings, collection) {
   const pool = util.getPgPool(settings.postgresql_uri)
 
   return {
-    pgpool: pool,
     init: async function () {
       await pool.query('CREATE TABLE IF NOT EXISTS ' + collection + ' (id text primary key, data jsonb)')
     },

--- a/db/postgres.js
+++ b/db/postgres.js
@@ -1,10 +1,9 @@
-const pg = require('pg')
 const uuid = require('node-uuid')
 const mongoToPostgres = require('mongo-query-to-postgres-jsonb')
 const util = require('../util')
 
 module.exports = function (settings, collection) {
-  const pool = new pg.Pool({ connectionString: settings.postgresql_uri })
+  const pool = util.getPgPool(settings.postgresql_uri)
 
   return {
     pgpool: pool,

--- a/index.js
+++ b/index.js
@@ -109,6 +109,9 @@ module.exports.api = function (settings) {
 
   router.setupCollectionDb = async function(collection) {
     debug(`init collection db ${collection._id} ${collection.storage}`)
+    if (collection.storage === 'postgres') {
+      router.db.pgpool = util.getPgPool(router.settings.postgresql_uri)
+    }
     router.db[collection._id] = dbTypes[collection.storage](router.settings, collection._id)
     if (collection.cacheInMemory) {
       router.db[collection._id] = dbTypes['cached'](router.db[collection._id])

--- a/test/db.js
+++ b/test/db.js
@@ -148,7 +148,7 @@ collectionNames.forEach(function (collection) {
 
     if (collection === 'postgrestest') {
       it('use pool to do query', async function () {
-        const res = await db.pgpool.query('SELECT $1::text as message', ['Hello world!'])
+        const res = await api.db.pgpool.query('SELECT $1::text as message', ['Hello world!'])
         expect(res.rows[0].message).to.equal('Hello world!')
       })
     }

--- a/util.js
+++ b/util.js
@@ -3,7 +3,7 @@ const jwt = require('jsonwebtoken')
 const debug = require('debug')('expressa')
 const crypto = require('crypto')
 const pg = require('pg')
-const pools = {}
+const pgPools = {}
 
 exports.orderBy = function (data, orderby) {
   data.sort(function compare (a, b) {
@@ -213,8 +213,8 @@ exports.friendlyDuration = function friendlyDuration (seconds) {
 }
 
 exports.getPgPool = function(connectionString) {
-  if (!pools[connectionString]) {
-    pools[connectionString] = new pg.Pool({ connectionString: connectionString })
+  if (!pgPools[connectionString]) {
+    pgPools[connectionString] = new pg.Pool({ connectionString: connectionString })
   }
-  return pools[connectionString]
+  return pgPools[connectionString]
 }

--- a/util.js
+++ b/util.js
@@ -212,7 +212,7 @@ exports.friendlyDuration = function friendlyDuration (seconds) {
   return Math.round(seconds) + ' seconds'
 }
 
-exports.getPgPool = function(connectionString) {
+exports.getPgPool = function getPgPool(connectionString) {
   if (!pgPools[connectionString]) {
     pgPools[connectionString] = new pg.Pool({ connectionString: connectionString })
   }

--- a/util.js
+++ b/util.js
@@ -2,6 +2,8 @@ const randomstring = require('randomstring')
 const jwt = require('jsonwebtoken')
 const debug = require('debug')('expressa')
 const crypto = require('crypto')
+const pg = require('pg')
+const pools = {}
 
 exports.orderBy = function (data, orderby) {
   data.sort(function compare (a, b) {
@@ -208,4 +210,11 @@ exports.friendlyDuration = function friendlyDuration (seconds) {
     return Math.round(seconds / 60) + ' minutes'
   }
   return Math.round(seconds) + ' seconds'
+}
+
+exports.getPgPool = function(connectionString) {
+  if (!pools[connectionString]) {
+    pools[connectionString] = new pg.Pool({ connectionString: connectionString })
+  }
+  return pools[connectionString]
 }


### PR DESCRIPTION
I know this is not perfect, but lets get a conversation going.

Created a utility `getPgPool` to create/retrieve a pgPool per connection string

Moved pgpool so its no longer per collection, but one layer above on the `api.db` layer.  This made more sense because custom queries are executed on the database and not necessarily per collection. Location of this assignment was chosen so that it would be done during both install and server restart

Very open to suggestions/improvements here

