### PR TITLE
Useful Things

### DIFF
--- a/auth/index.js
+++ b/auth/index.js
@@ -21,7 +21,7 @@ exports.middleware = function authMiddleware(req, res, next) {
     next()
   }
   Promise.resolve(asyncFn(req, res, next)).catch((e) => {
-    const error = e.message = 'jwt expired' ? 'expired token' : 'jwt error'
+    const error = e.message === 'jwt expired' ? 'expired token' : 'jwt error'
     res.status(400).send({ error })
   })
 }

--- a/auth/index.js
+++ b/auth/index.js
@@ -20,5 +20,8 @@ exports.middleware = function authMiddleware(req, res, next) {
     }
     next()
   }
-  Promise.resolve(asyncFn(req, res, next)).catch(next)
+  Promise.resolve(asyncFn(req, res, next)).catch((e) => {
+    const error = e.message = 'jwt expired' ? 'expired token' : 'jwt error'
+    res.status(400).send({ error })
+  })
 }

--- a/auth/jwt.js
+++ b/auth/jwt.js
@@ -4,14 +4,14 @@ const util = require('../util')
 
 // User document already validated, created, and saved to database
 // The id of that document is given.
-exports.doLogin = function (user, req) {
+exports.doLogin = function (user, req, options = {}) {
   if (!req.settings.jwt_secret) {
     throw new util.ApiError(500, 'missing jwt_secret in settings')
   }
   const token = jwt.sign({
     _id: user._id,
     email: user.email
-  }, req.settings.jwt_secret, {})
+  }, req.settings.jwt_secret, options)
   return {
     token: token,
     uid: user._id

--- a/controllers/status.js
+++ b/controllers/status.js
@@ -28,7 +28,7 @@ exports.getStatus = function(router) {
       return o
     })
     listeners.sort((a, b) => a.priority - b.priority)
-    const collections = Object.keys(router.db).filter((col) => col !== 'pgpool')
+    const collections = Object.keys(router.db)
     return {
       nodeVersion: process.version,
       uptime: util.friendlyDuration(process.uptime()),

--- a/index.js
+++ b/index.js
@@ -107,6 +107,9 @@ module.exports.api = function (settings) {
     settings: dbTypes[router.settings.settings_db_type || 'file'](router.settings, 'settings')
   }
   router.util = {
+    get pgpool() {
+      return util.getPgPool(router.settings.postgresql_uri)
+    },
     ApiError: util.ApiError,
     generateDocumentId: util.generateDocumentId,
     doLogin: auth.doLogin
@@ -115,9 +118,6 @@ module.exports.api = function (settings) {
 
   router.setupCollectionDb = async function(collection) {
     debug(`init collection db ${collection._id} ${collection.storage}`)
-    if (collection.storage === 'postgres') {
-      router.db.pgpool = util.getPgPool(router.settings.postgresql_uri)
-    }
     router.db[collection._id] = dbTypes[collection.storage](router.settings, collection._id)
     if (collection.cacheInMemory) {
       router.db[collection._id] = dbTypes['cached'](router.db[collection._id])

--- a/index.js
+++ b/index.js
@@ -106,6 +106,11 @@ module.exports.api = function (settings) {
   router.db = {
     settings: dbTypes[router.settings.settings_db_type || 'file'](router.settings, 'settings')
   }
+  router.util = {
+    ApiError: util.ApiError,
+    generateDocumentId: util.generateDocumentId,
+    doLogin: auth.doLogin
+  }
   router.eventListeners = {}
 
   router.setupCollectionDb = async function(collection) {

--- a/test/db.js
+++ b/test/db.js
@@ -149,7 +149,7 @@ collectionNames.forEach(function (collection) {
 
     if (collection === 'postgrestest') {
       it('use pool to do query', async function () {
-        const res = await api.db.pgpool.query('SELECT $1::text as message', ['Hello world!'])
+        const res = await api.util.pgpool.query('SELECT $1::text as message', ['Hello world!'])
         expect(res.rows[0].message).to.equal('Hello world!')
       })
     }


### PR DESCRIPTION
jwt error: if an error is thrown here, the generic `something went wrong` error is thrown, because the user cannot be logged in. clients may need a little more detail (for example if expired token) to know how best to react for user. I didnt want to simply pass the jwt error in case it might contain sensitive info so limited the message for now

added `options` param for `doLogin` - paves the way for expiring tokens. I have tested this on my project for pasword resets and works fine

created the `util` object on the router as discussed in #121 

moved `pgpool` from the `db` object and onto the `util` object as i think this is a more appropriate place for it, also considering how the db object is iterated over for the admin ui