### PR TITLE
Graceful Token Error

### DIFF
--- a/auth/index.js
+++ b/auth/index.js
@@ -12,17 +12,16 @@ exports.isValidPassword = function (password, hashedPassword) {
 
 exports.doLogin = handler.doLogin
 
-exports.middleware = function authMiddleware(req, res, next) {
-  const asyncFn = async (req, res, next) => {
+exports.middleware = async function authMiddleware(req, res, next) {
+  try {
     const user = await handler.isLoggedIn(req)
     if (user) {
       req.uid = user._id
       req.ucollection = user.collection
     }
-    next()
   }
-  Promise.resolve(asyncFn(req, res, next)).catch((e) => {
-    const error = e.message === 'jwt expired' ? 'expired token' : 'jwt error'
-    res.status(400).send({ error })
-  })
+  catch(e) {
+    req.uerror = e.message === 'jwt expired' ? 'expired token' : 'jwt error'
+  }
+  next()
 }

--- a/index.js
+++ b/index.js
@@ -89,11 +89,11 @@ function ph (requestHandler) {
       res.send(result)
     } catch (err) {
       err.status = err.status || 500
-      debug(`${err.status} ${req.method} ${req.url} ${err.stack}`)
+      debug(`${err.status} ${req.method} ${req.url} ${err.stack} ${req.uerror}`)
       if ((req.settings.print_400_errors) || err.status >= 500) {
-        console.error(err)
+        console.error(err + ' | ' + req.uerror)
       }
-      res.status(err.status).send({ error: err.result || err.message || err })
+      res.status(err.status).send({ error: err.result || err.message || err, authError: req.uerror })
     }
   }
 }


### PR DESCRIPTION
Previoulsy i submitted a PR which forcefully threw an error if login failed or if the jwt expired

This was short sighted - sometimes a valid login is not necessary depending on the collection/endpoint and there is no sense failing the request simply because a token is present. Including a token on all requests makes client development a lot easier than having to painfully pick and choose which requests require it and which dont

This PR allows a request to continue if login fails or jwt problem/expired and sends this information separately as an `authError` property. This is no less secure since permissions model still holds true, and is actually a revert of what always worked but now we're sending more meaningful `authError` back to client