### PR TITLE
Add update with query to db layer

### DIFF
--- a/controllers/collections.js
+++ b/controllers/collections.js
@@ -1,6 +1,5 @@
 const debug = require('debug')('expressa')
 const MongoQS = require('mongo-querystring')
-const mongoQuery = require('mongo-query')
 
 const util = require('../util')
 const queryStringParser = new MongoQS({})
@@ -120,7 +119,7 @@ exports.updateById = async function (req) {
 
   const doc = await req.db[req.params.collection].get(req.params.id)
   const owner = doc.meta && doc.meta.owner
-  mongoQuery(doc, {}, modifier)
+  util.mongoUpdate(doc, modifier)
   const newOwner = doc.meta && doc.meta.owner
   if (owner !== newOwner) {
     debug('attempting to change document owner.')

--- a/db/cached.js
+++ b/db/cached.js
@@ -25,6 +25,10 @@ module.exports = function (storage) {
       await cache.update(id, data)
       return storage.update(id, data)
     },
+    updateWithQuery: async function (query, update, options) {
+      await cache.updateWithQuery(query, update, options)
+      return storage.updateWithQuery(query, update, options)
+    },
     delete: async function (id) {
       await cache.delete(id)
       return storage.delete(id)

--- a/db/file.js
+++ b/db/file.js
@@ -89,6 +89,16 @@ module.exports = function (settings, collection) {
       }
       return data
     },
+    updateWithQuery: async function (query, update, options) {
+      const data = await store.allAsync()
+      const arr = Object.keys(data).map((id) => ({ _id: id, ...data[id]}) )
+      const matches = sift(query || {}, arr)
+      const promises = matches.map((doc) => {
+        util.mongoUpdate(doc, update)
+        return store.saveAsync(doc._id, doc)
+      })
+      await Promise.all(promises)
+    },
     delete: async function (id) {
       await this.get(id) // to check if exists
       await store.delete(id)

--- a/db/file.js
+++ b/db/file.js
@@ -98,6 +98,9 @@ module.exports = function (settings, collection) {
         return store.saveAsync(doc._id, doc)
       })
       await Promise.all(promises)
+      return {
+        matchedCount: promises.length
+      }
     },
     delete: async function (id) {
       await this.get(id) // to check if exists

--- a/db/memory.js
+++ b/db/memory.js
@@ -63,6 +63,9 @@ module.exports = function (settings, collection) {
         util.mongoUpdate(doc, update)
         store[doc._id] = doc
       })
+      return {
+        matchedCount: matches.length
+      }
     },
     delete: async function (id) {
       if (store[id]) {

--- a/db/memory.js
+++ b/db/memory.js
@@ -13,9 +13,7 @@ module.exports = function (settings, collection) {
       return this.find({})
     },
     find: async function (query, offset, limit, orderby, fields) {
-      const arr = Object.keys(store).map(function (id) {
-        return store[id]
-      })
+      const arr = Object.values(store)
       let matches = sift(query || {}, arr)
       if (orderby) {
         matches = util.orderBy(matches, orderby)
@@ -55,6 +53,16 @@ module.exports = function (settings, collection) {
       data._id = data._id || id
       store[id] = data
       return data
+    },
+    // Designed to match Mongo
+    // https://docs.mongodb.com/manual/reference/method/db.collection.updateMany/
+    updateWithQuery: async function (query, update, options) {
+      const arr = Object.keys(store).map((id) => ({ _id: id, ...store[id]}) )
+      const matches = sift(query || {}, arr)
+      matches.forEach((doc) => {
+        util.mongoUpdate(doc, update)
+        store[doc._id] = doc
+      })
     },
     delete: async function (id) {
       if (store[id]) {

--- a/db/mongo.js
+++ b/db/mongo.js
@@ -69,7 +69,10 @@ module.exports = function (settings, collection) {
     },
     updateWithQuery: async function (query, update, options) {
       const db = await this.getClient()
-      await db.collection(collection).updateMany(query, update, options)
+      const res = await db.collection(collection).updateMany(query, update, options)
+      return {
+        matchedCount: res.matchedCount
+      }
     },
     delete: async function (id) {
       const db = await this.getClient()

--- a/db/mongo.js
+++ b/db/mongo.js
@@ -67,6 +67,10 @@ module.exports = function (settings, collection) {
       // doc._id = doc._id.toString()
       return data
     },
+    updateWithQuery: async function (query, update, options) {
+      const db = await this.getClient()
+      await db.collection(collection).updateMany(query, update, options)
+    },
     delete: async function (id) {
       const db = await this.getClient()
       const res = await db.collection(collection).deleteOne({

--- a/db/postgres.js
+++ b/db/postgres.js
@@ -74,6 +74,9 @@ module.exports = function (settings, collectionId, collection) {
       if (result.rowCount === 0) {
         throw new util.ApiError(404, 'document not found')
       }
+      return {
+        matchedCount: result.rowCount
+      }
     },
     delete: async function (id) {
       const result = await pool.query('DELETE FROM ' + collectionId + ' WHERE id=$1', [id])

--- a/db/postgres.js
+++ b/db/postgres.js
@@ -66,6 +66,15 @@ module.exports = function (settings, collectionId, collection) {
       }
       return data
     },
+    updateWithQuery: async function (query, update, options) {
+      const arrayFields = util.getArrayPaths('', collection.schema)
+      const pgQuery = mongoToPostgres('data', query || {}, arrayFields)
+      const updateSql = mongoToPostgres.convertUpdate('data', update,false)
+      const result = await pool.query('UPDATE ' + collectionId + ' SET data=' + updateSql + ' WHERE ' + pgQuery)
+      if (result.rowCount === 0) {
+        throw new util.ApiError(404, 'document not found')
+      }
+    },
     delete: async function (id) {
       const result = await pool.query('DELETE FROM ' + collectionId + ' WHERE id=$1', [id])
       if (result.rowCount === 0) {

--- a/modules/permissions/permissions.js
+++ b/modules/permissions/permissions.js
@@ -1,5 +1,3 @@
-const util = require('../../util')
-
 exports.settingSchema = {
   enforce_permissions: {
     type: 'boolean',

--- a/test/db.updating.js
+++ b/test/db.updating.js
@@ -118,7 +118,8 @@ collectionNames.forEach(function (collection) {
     })
 
     it('update by query with id', async function () {
-      await db.updateWithQuery({ _id: id }, { $set: { title: 'first22' } })
+      const res = await db.updateWithQuery({ _id: id }, { $set: { title: 'first22' } })
+      expect(res.matchedCount).to.equal(1)
 
       const doc = await db.get(id)
       expect(doc.title).to.equal('first22')
@@ -128,13 +129,15 @@ collectionNames.forEach(function (collection) {
       let docs = await db.find({})
       expect(docs).to.have.length(3)
 
-      await db.updateWithQuery({ 'data.field': '123' }, { $set: { test: true } })
+      const res1 = await db.updateWithQuery({ 'data.field': '123' }, { $set: { test: true } })
       docs = await db.find({test: true })
       expect(docs).to.have.length(2)
+      expect(res1.matchedCount).to.equal(2)
 
-      await db.updateWithQuery({ 'data.field': { $in: ['123', '12345'] } }, { $set: { test: true } })
+      const res2 = await db.updateWithQuery({ 'data.field': { $in: ['123', '12345'] } }, { $set: { test: true } })
       docs = await db.find({ test: true })
       expect(docs).to.have.length(3)
+      expect(res2.matchedCount).to.equal(3)
     })
   })
 })

--- a/test/db.updating.js
+++ b/test/db.updating.js
@@ -1,0 +1,141 @@
+const chai = require('chai')
+const expect = chai.expect
+const request = require('supertest')
+const testutils = require('./testutils')
+const { app, api } = testutils
+
+const collectionNames = ['memorytest', 'filetest']
+if (process.env.TEST_MONGO) {
+  collectionNames.push('mongotest')
+}
+if (process.env.TEST_POSTGRES) {
+  collectionNames.push('postgrestest')
+}
+
+collectionNames.forEach(function (collection) {
+  describe(`${collection} updating`, function () {
+    let db
+    let id
+    const collectionName = collection + '3'
+
+    before(async function () {
+      const coll = {
+        _id: collectionName,
+        schema: {
+          type: 'object',
+          additionalProperties: false,
+          properties: {
+            _id: {
+              type: 'string'
+            },
+            title: {
+              type: 'string'
+            },
+            data: {
+              type: 'object',
+              additionalProperties: true,
+              properties: {
+                nestedArr: {
+                  type: 'array',
+                  items: {
+                    type: 'string'
+                  }
+                },
+              }
+            },
+            arr: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  color: {
+                    type: 'string'
+                  },
+                  num: {
+                    type: 'number'
+                  },
+                  subarray: {
+                    type: 'array',
+                    items: {
+                      type: 'object',
+                      properties: {
+                        v: {
+                          type: 'string'
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            meta: {
+              type: 'object',
+              propertyOrder: 2000,
+              properties: {
+                created: {
+                  type: 'string'
+                },
+                updated: {
+                  type: 'string'
+                },
+              }
+            }
+          },
+          required: [
+            'title'
+          ]
+        },
+        storage: collection.replace('test', ''),
+        documentsHaveOwners: false,
+      }
+
+      const token = await testutils.getUserWithPermissions(api, 'collection: create')
+      await request(app)
+        .post('/collection')
+        .set('x-access-token', token)
+        .send(coll)
+        .expect(200)
+
+      db = api.db[collection]
+
+      id = await db.create({
+        title: 'first',
+        data: { field: '123' },
+        arr: [{ color: 'red', subarray: [{ v: 'abc' }] }],
+      })
+
+      await db.create({
+        title: 'second',
+        data: { field: '123' },
+        arr: [{ color: 'red', subarray: [{ v: 'abc' }] }],
+      })
+
+      await db.create({
+        title: 'third',
+        data: { field: '12345' },
+        arr: [{ color: 'red', subarray: [{ v: 'abc' }] }],
+      })
+    })
+
+    it('update by query with id', async function () {
+      await db.updateWithQuery({ _id: id }, { $set: { title: 'first22' } })
+
+      const doc = await db.get(id)
+      expect(doc.title).to.equal('first22')
+    })
+
+    it('update by query with sub field', async function () {
+      let docs = await db.find({})
+      expect(docs).to.have.length(3)
+
+      await db.updateWithQuery({ 'data.field': '123' }, { $set: { test: true } })
+      docs = await db.find({test: true })
+      expect(docs).to.have.length(2)
+
+      await db.updateWithQuery({ 'data.field': { $in: ['123', '12345'] } }, { $set: { test: true } })
+      docs = await db.find({ test: true })
+      expect(docs).to.have.length(3)
+    })
+  })
+})
+

--- a/util.js
+++ b/util.js
@@ -6,6 +6,7 @@ const crypto = require('crypto')
 const pg = require('pg')
 const pgPools = {}
 const dot = require('dot-object')
+const mongoQuery = require('mongo-query')
 
 exports.orderBy = function (data, orderby) {
   data.sort(function compare (a, b) {
@@ -108,6 +109,10 @@ exports.mongoProject = function(record, projection) {
   const expanded = dot.object(projection)
   const result = isInclude ? _include(record, expanded) : _exclude(record, expanded)
   return result
+}
+
+exports.mongoUpdate = function(doc, update) {
+  return mongoQuery(doc, {}, update)
 }
 
 exports.normalizeOrderBy = function(orderby) {


### PR DESCRIPTION
This is for issue #137

* MongoDB provides a parameter called `multi` which lets you control if you want to update just one or many documents.
* MongoDB also returns in the result `modifiedCount` and I'm thinking it could be nice for all the implementations to do that.

@kane-mason Let me know your thoughts, thanks!