### PR TITLE
Req User Additional Props

### DIFF
--- a/listeners_validation.js
+++ b/listeners_validation.js
@@ -55,7 +55,7 @@ module.exports = async function (api) {
     }
     const isValid = schemaValidators[collection](data)
     if (!isValid) {
-      throw new util.ApiError(400, schemaValidators[collection].errors.map((err) => err.message).join(', '))
+      throw new util.ApiError(400, schemaValidators[collection].errors.map((err) => `${err.message}: ${JSON.stringify(err.params)}`).join(', '))
     }
   })
 }

--- a/middleware/users_permissions.js
+++ b/middleware/users_permissions.js
@@ -1,12 +1,12 @@
 const util = require('../util')
 
-async function addRolePermissions (req, user, roles) {
-  user.permissions = user.permissions || {}
+async function addRolePermissions (req, roles) {
+  req.userPermissions = req.userPermissions || {}
   const roleDocs = await Promise.all(roles.map((name) => req.db.role.get(name)))
   roleDocs.forEach((roleDoc) => {
     for (const permission in roleDoc.permissions) {
       if (roleDoc.permissions[permission]) {
-        user.permissions[permission] = true
+        req.userPermissions[permission] = true
       }
     }
   })
@@ -27,7 +27,7 @@ module.exports.addRolePermissionsAsync = async function addRolePermissionsMiddle
     req.hasPermission = () => true
     return
   }
-  req.hasPermission = (permission) => req.user && req.user.permissions[permission]
+  req.hasPermission = (permission) => req.userPermissions && req.userPermissions[permission]
   let roles = ['Anonymous']
   const isAuthenticatedRole = await doesAuthenticatedRoleExist(req)
   if (req.uid) {
@@ -41,7 +41,7 @@ module.exports.addRolePermissionsAsync = async function addRolePermissionsMiddle
   } else {
     req.user = { permissions: {} }
   }
-  await addRolePermissions(req, req.user, roles)
+  await addRolePermissions(req, roles)
 }
 
 module.exports.middleware = function addRolePermissionsMiddleware (req, res, next) {

--- a/test/users.js
+++ b/test/users.js
@@ -95,7 +95,6 @@ describe('user functionality', function () {
 
   it('cannot change role by default', async function () {
     const token = await testutils.getUserWithPermissions(api, ['users: view', 'users: edit'])
-    delete user.permissions
     delete user.collection
     await request(app)
       .put(`/users/${user._id}`)
@@ -117,7 +116,6 @@ describe('user functionality', function () {
 
   it('can change role with correct permission', async function () {
     const token = await testutils.getUserWithPermissions(api, ['users: view', 'users: edit', 'users: modify roles'])
-    delete user.permissions
     await request(app)
       .post(`/users/${user._id}/update`)
       .set('x-access-token', token)


### PR DESCRIPTION
For each authenticated request, the `user` is retrieved from the database and stored on the `req`. This is useful if you need to retrieve the user for any listener action on the request as you do not have to do it again, however the `permission` property that is added by expressa onto the user prevents you from using the `user` interchangably with the database as it will (rightly so) be viewed as an additional property which will cause validation error. 

To solve this i pulled `user.permissions` off the `req.user` and put in in its own `req.userPermissions` object.

Also updated the error message thrown from valivation errors to provide useful hints as to what failed validation (i think this was as  result of `ajv` update)