### PR TITLE
Clean up AJV Warnings

### DIFF
--- a/listeners_validation.js
+++ b/listeners_validation.js
@@ -5,6 +5,18 @@ const ajv = new Ajv({
   strictSchema: 'log',
   validateFormats: false,
 })
+ajv.addKeyword({
+  keyword: 'links',
+  type: 'string',
+  schemaType: 'array',
+})
+ajv.addKeyword({
+  keyword: 'media',
+  type: 'string',
+  schemaType: 'object',
+})
+const formatKey = ajv.getKeyword('format')
+formatKey.type = formatKey.type.concat(['array', 'boolean', 'object'])
 
 const util = require('./util')
 const schemaValidators = {}


### PR DESCRIPTION
Expressa requires:

Added keywords `links` and `media`
Updated keyword `format` to accepts types `array`, `boolean` and `object` 

Fixes https://github.com/thomas4019/expressa/issues/148