### PR TITLE
fix: make edit json textarea expandable

### DIFF
--- a/modules/admin/src/components/JSONEditor.vue
+++ b/modules/admin/src/components/JSONEditor.vue
@@ -55,6 +55,14 @@ export default {
         }
         this.$emit('input', this.editor.getValue())
       })
+
+      const makeEditJsonTextAreaExpandable = () => {
+        const textarea = document.querySelector('.je-modal .je-edit-json--textarea')
+        textarea.classList.remove('je-edit-json--textarea') // INFO: Had to remove this class to remove height and width property
+        textarea.classList.add('expandable-textarea')
+      }
+
+      makeEditJsonTextAreaExpandable()
     },
     onSave() {
       this.$emit('json-save', this.json)
@@ -71,15 +79,8 @@ if (JSONEditor) {
     // If no valid editor is returned, the next resolver function will be used
   })
 
-  JSONEditor.defaults.callbacks.template = {
-    'deleteProfilePic': (jseditor, e) => {
-      alert('hey')
-    }
-  }
-
   JSONEditor.defaults.editors.schema = class schema extends JSONEditor.AbstractEditor {
     setValue(value, initial) {
-      console.log(this)
       this.value = value
       this.schemaeditor.setValue(value)
       this.onChange()
@@ -150,8 +151,11 @@ if (JSONEditor) {
 </script>
 
 <style>
-  h3 textarea {
-    resize: both;
+  .expandable-textarea {
+    display: block;
+    min-height: 250px;
+    min-width: 250px;
+    resize: both !important;
   }
   .jsoneditor-vue button.btn {
     font-size: 14px !important;


### PR DESCRIPTION
This PR will make sure we can expand the below text area and make our changes more effectively.

![image](https://user-images.githubusercontent.com/17315781/132976661-5b7d17fb-2584-484c-8f8b-77e94ff67ec3.png)

ps- To make the Textarea resizable, I had to remove the default `je-edit-json--textarea` class because it had `height` and `width` property which I could not reset. Even `auto` did not work.