### PR TITLE
Pagination Optimize

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,10 @@ Once you add a collections in the admin interface, every collection will have th
 | POST   | /users/login                                 | expects JSON in the message body. e.g. `{"email": "email@example.com", password: "<the password>"}                                                                                             |
 | GET    | /:collection                                 | get an array of all documents in a collection                                                                                                                                                  |
 | GET    | /:collection/:id                             | get a specific document                                                                                                                                                                        |
-| GET    | /:collection/?query={..}                     | get an array of documents matching the [mongo query](https://www.npmjs.com/package/mongo-query). For pagination append `&skip=0&offset=0&limit=6`                                              |
-| GET    | /:collection/?query={..}&limit=10&page=1&orderby=["meta.created"] | same as previous, but with pagination support |
-| GET    | /:collection/?query={..}&limit=10&offset=10 | same as previous, but with finergrained output control |
+| GET    | /:collection/?query={..}                     | get an array of documents matching the [mongo query](https://www.npmjs.com/package/mongo-query)                                            |
+| GET    | /:collection/?query={..}&limit=10&offset=10&orderby={"meta.created":1}  | same as previous, but with targeted output control and sorting |
+| GET    | /:collection/?query={..}&page=1&pageitems=10 | similar to previous, but with pagination support |
+| GET    | /:collection/?query={..}&page=1&pageitems=10&pagemetadisable=1 | same as previous but *slightly* faster and with less pagination detail |
 | GET    | /:collection/?query={..}&fields={..}         | the fields param can be used to do a mongo projection to request only specific fields |
 | GET    | /:collection/?fieldname=value                | get an array of documents matching with the specified values. See [node-mongo-querystring](https://github.com/Turistforeningen/node-mongo-querystring) for details.                            |
 | GET    | /:collection/schema                          | get the collection schema                                                                                                                                                                      |

--- a/controllers/collections.js
+++ b/controllers/collections.js
@@ -59,7 +59,6 @@ exports.get = async function (req) {
     if (req.query.pagemetadisable) {
       // a way to skip the extra count database call, but lose additional page detail
       pageData = await req.db[req.params.collection].find(query, req.query.offset, req.query.pageitems, req.query.orderby, fields)
-      data = util.createPagePagination(pageData, req.query.page, req.query.pageitems)
     }
     else {
       // this is default - full detail

--- a/controllers/collections.js
+++ b/controllers/collections.js
@@ -52,7 +52,7 @@ exports.get = async function (req) {
     }
     req.query.pageitems = parseInt(req.query.pageitems) || parseInt(req.query.limit) || 10
     req.query.offset = util.getDatabaseOffset(req.query.page, req.query.pageitems)
-    req.query.orderby = req.query.orderby || util.normalizeOrderBy({ 'meta.created': 1 })
+    req.query.orderby = req.query.orderby || util.normalizeOrderBy({ 'meta.created': 1 }) // paging requires orderby to ensure consistent results with offset and limit
     delete req.query.limit
     delete req.query.skip
     const pageData = await req.db[req.params.collection].find(query, req.query.offset, req.query.pageitems, req.query.orderby, fields)

--- a/db/cached.js
+++ b/db/cached.js
@@ -15,7 +15,7 @@ module.exports = function (storage) {
       return cache.find(query, offset, limit, orderby, fields)
     },
     count: async function(...params) {
-      return (await this.find(...params)).length
+      return await cache.count(...params)
     },
     get: function (id, fields) {
       return cache.get(id, fields)

--- a/db/cached.js
+++ b/db/cached.js
@@ -14,6 +14,9 @@ module.exports = function (storage) {
     find: function (query, offset, limit, orderby, fields) {
       return cache.find(query, offset, limit, orderby, fields)
     },
+    count: async function(...params) {
+      return (await this.find(...params)).length
+    },
     get: function (id, fields) {
       return cache.get(id, fields)
     },

--- a/db/file.js
+++ b/db/file.js
@@ -46,6 +46,9 @@ module.exports = function (settings, collection) {
       }
       return matches
     },
+    count: async function(...params) {
+      return (await this.find(...params)).length
+    },
     get: async function (id, fields) {
       try {
         let data = await store.getAsync(id)

--- a/db/memory.js
+++ b/db/memory.js
@@ -30,6 +30,9 @@ module.exports = function (settings, collection) {
       }
       return matches
     },
+    count: async function(...params) {
+      return (await this.find(...params)).length
+    },
     get: async function (id, fields) {
       if (!store[id]) {
         throw new util.ApiError(404, 'document not found')

--- a/db/mongo.js
+++ b/db/mongo.js
@@ -34,6 +34,9 @@ module.exports = function (settings, collection) {
       })
       return docs
     },
+    count: async function(...params) {
+      return (await this.find(...params)).length
+    },
     get: async function (id, fields) {
       const db = await this.getClient()
       const doc = await db.collection(collection).findOne({ _id: id }, { fields })

--- a/db/mongo.js
+++ b/db/mongo.js
@@ -33,7 +33,7 @@ module.exports = function (settings, collection) {
     },
     get: async function (id, fields) {
       const db = await this.getClient()
-      const doc = await db.collection(collection).findOne({ _id: id }, { fields })
+      const doc = await db.collection(collection).findOne({ _id: id }, { projection: fields })
       if (doc) {
         doc._id = doc._id.toString()
       }

--- a/db/mongo.js
+++ b/db/mongo.js
@@ -19,13 +19,7 @@ module.exports = function (settings, collection) {
     },
     find: async function (query, skip, limit, orderby, fields) {
       const db = await this.getClient()
-      const cursor = db.collection(collection).find(query, { fields }).sort(orderby)
-      if (typeof skip !== 'undefined') {
-        cursor.skip(skip)
-      }
-      if (typeof limit !== 'undefined') {
-        cursor.limit(limit)
-      }
+      const cursor = db.collection(collection).find(query, { skip, limit, projection: fields, sort: orderby })
       const docs = await cursor.toArray()
       docs.forEach((doc) => {
         if (doc._id) {

--- a/db/mongo.js
+++ b/db/mongo.js
@@ -28,8 +28,10 @@ module.exports = function (settings, collection) {
       })
       return docs
     },
-    count: async function(...params) {
-      return (await this.find(...params)).length
+    count: async function(query, skip, limit) {
+      const db = await this.getClient()
+      const count = await db.collection(collection).count(query, { skip, limit })
+      return count
     },
     get: async function (id, fields) {
       const db = await this.getClient()

--- a/db/postgres.js
+++ b/db/postgres.js
@@ -35,6 +35,9 @@ module.exports = function (settings, collectionId, collection) {
       const result = await pool.query(query)
       return result.rows.map((row) => row.data)
     },
+    count: async function(...params) {
+      return (await this.find(...params)).length
+    },
     get: async function (id, fields) {
       const arrayFields = util.getArrayPaths('', collection.schema)
       const select = fields ? mongoToPostgres.convertSelect('data', fields, arrayFields) : '*'

--- a/db/postgres.js
+++ b/db/postgres.js
@@ -35,8 +35,18 @@ module.exports = function (settings, collectionId, collection) {
       const result = await pool.query(query)
       return result.rows.map((row) => row.data)
     },
-    count: async function(...params) {
-      return (await this.find(...params)).length
+    count: async function(rawQuery, offset, limit) {
+      const arrayFields = util.getArrayPaths('', collection.schema)
+      const pgQuery = mongoToPostgres('data', rawQuery || {}, arrayFields)
+      let query = 'SELECT COUNT(*) FROM ' + collectionId + (pgQuery ? ' WHERE ' + pgQuery : '')
+      if (typeof offset !== 'undefined') {
+        query += ' OFFSET ' + offset
+      }
+      if (typeof limit !== 'undefined') {
+        query += ' LIMIT ' + limit
+      }
+      const result = await pool.query(query)
+      return parseInt(result.rows[0].count)
     },
     get: async function (id, fields) {
       const arrayFields = util.getArrayPaths('', collection.schema)

--- a/index.js
+++ b/index.js
@@ -117,7 +117,9 @@ module.exports.api = function (settings) {
     generateDocumentId: util.generateDocumentId,
     doLogin: auth.doLogin,
     createPagination: util.createPagination,
-    normalizeOrderBy: util.normalizeOrderBy
+    createPagePagination: util.createPagePagination,
+    normalizeOrderBy: util.normalizeOrderBy,
+    getDatabaseOffset: util.getDatabaseOffset,
   }
   router.eventListeners = {}
 

--- a/modules/admin/src/views/ListDocuments2.vue
+++ b/modules/admin/src/views/ListDocuments2.vue
@@ -172,6 +172,7 @@ export default {
     allFilters() {
       const params = {
         page: this.page,
+        pageMeta: 1,
         limit: this.pageSize,
         orderby: '{"meta.created":-1}',
         ...this.filter,

--- a/modules/admin/src/views/ListDocuments2.vue
+++ b/modules/admin/src/views/ListDocuments2.vue
@@ -172,7 +172,6 @@ export default {
     allFilters() {
       const params = {
         page: this.page,
-        pageMeta: 1,
         limit: this.pageSize,
         orderby: '{"meta.created":-1}',
         ...this.filter,

--- a/test/collections.js
+++ b/test/collections.js
@@ -159,11 +159,10 @@ describe('basic collections', function () {
 
   it('fail to read paged without permission', async function () {
     const token = await testutils.getUserWithPermissions(api)
-    const res = await request(app)
+    await request(app)
       .get('/testdoc/?page=1')
       .set('x-access-token', token)
-      .expect(200)
-    expect(res.body.data.length).to.equal(0)
+      .expect(401)
   })
 
   it('read a specific doc', async function () {

--- a/test/collections.querying.js
+++ b/test/collections.querying.js
@@ -102,11 +102,10 @@ describe('querying collections', function () {
     expect(res.body).to.have.lengthOf(1)
   })
 
-  it('returns no documents without permission', async function () {
-    const res = await request(app)
+  it('errors without permission', async function () {
+    await request(app)
       .get('/testdoc')
-      .expect(200)
-    expect(res.body).to.have.lengthOf(0)
+      .expect(401)
   })
 
   it('page 0 returns an error', async function () {

--- a/test/collections.querying.js
+++ b/test/collections.querying.js
@@ -146,6 +146,21 @@ describe('querying collections', function () {
     expect(res.body.data[0].title).to.equal('doc3')
   })
 
+  it('pagemetadisable url parameter strips additional page detail', async function () {
+    const res = await request(app)
+      .get('/testdoc?limit=2&page=2&pagemetadisable=1')
+      .set('x-access-token', token)
+      .expect(200)
+    expect(res.body.itemsTotal).to.equal(undefined)
+    expect(res.body.itemsPerPage).to.equal(2)
+    expect(res.body.pages).to.equal(undefined)
+    expect(res.body.pagePrev).to.equal(1)
+    expect(res.body.pageNext).to.equal(undefined)
+    expect(res.body.data).to.have.lengthOf(1)
+
+    expect(res.body.data[0].title).to.equal('doc3')
+  })
+
   it('page 3 is empty', async function () {
     const res = await request(app)
       .get('/testdoc?limit=2&page=3')

--- a/test/collections.querying.js
+++ b/test/collections.querying.js
@@ -117,7 +117,7 @@ describe('querying collections', function () {
 
   it('returns page 1 correctly', async function () {
     const res = await request(app)
-      .get('/testdoc?limit=2&page=1&pageMeta=1')
+      .get('/testdoc?limit=2&page=1')
       .set('x-access-token', token)
       .expect(200)
     expect(res.body.itemsTotal).to.equal(3)
@@ -133,7 +133,7 @@ describe('querying collections', function () {
 
   it('returns page 2 correctly', async function () {
     const res = await request(app)
-      .get('/testdoc?limit=2&page=2&pageMeta=1')
+      .get('/testdoc?limit=2&page=2')
       .set('x-access-token', token)
       .expect(200)
     expect(res.body.itemsTotal).to.equal(3)
@@ -148,7 +148,7 @@ describe('querying collections', function () {
 
   it('page 3 is empty', async function () {
     const res = await request(app)
-      .get('/testdoc?limit=2&page=3&pageMeta=1')
+      .get('/testdoc?limit=2&page=3')
       .set('x-access-token', token)
       .expect(200)
     expect(res.body.itemsTotal).to.equal(3)
@@ -161,7 +161,7 @@ describe('querying collections', function () {
 
   it('page 4 is empty', async function () {
     const res = await request(app)
-      .get('/testdoc?limit=2&page=3&pageMeta=1')
+      .get('/testdoc?limit=2&page=3')
       .set('x-access-token', token)
       .expect(200)
     expect(res.body.itemsTotal).to.equal(3)
@@ -174,7 +174,7 @@ describe('querying collections', function () {
 
   it('pagination works with query', async function () {
     const res = await request(app)
-      .get('/testdoc?query={"data.number":2}&limit=2&page=1&pageMeta=1')
+      .get('/testdoc?query={"data.number":2}&limit=2&page=1')
       .set('x-access-token', token)
       .expect(200)
     expect(res.body.itemsTotal).to.equal(1)

--- a/test/collections.querying.js
+++ b/test/collections.querying.js
@@ -118,7 +118,7 @@ describe('querying collections', function () {
 
   it('returns page 1 correctly', async function () {
     const res = await request(app)
-      .get('/testdoc?limit=2&page=1')
+      .get('/testdoc?limit=2&page=1&pageMeta=1')
       .set('x-access-token', token)
       .expect(200)
     expect(res.body.itemsTotal).to.equal(3)
@@ -134,7 +134,7 @@ describe('querying collections', function () {
 
   it('returns page 2 correctly', async function () {
     const res = await request(app)
-      .get('/testdoc?limit=2&page=2')
+      .get('/testdoc?limit=2&page=2&pageMeta=1')
       .set('x-access-token', token)
       .expect(200)
     expect(res.body.itemsTotal).to.equal(3)
@@ -149,7 +149,7 @@ describe('querying collections', function () {
 
   it('page 3 is empty', async function () {
     const res = await request(app)
-      .get('/testdoc?limit=2&page=3')
+      .get('/testdoc?limit=2&page=3&pageMeta=1')
       .set('x-access-token', token)
       .expect(200)
     expect(res.body.itemsTotal).to.equal(3)
@@ -162,7 +162,7 @@ describe('querying collections', function () {
 
   it('page 4 is empty', async function () {
     const res = await request(app)
-      .get('/testdoc?limit=2&page=3')
+      .get('/testdoc?limit=2&page=3&pageMeta=1')
       .set('x-access-token', token)
       .expect(200)
     expect(res.body.itemsTotal).to.equal(3)
@@ -175,7 +175,7 @@ describe('querying collections', function () {
 
   it('pagination works with query', async function () {
     const res = await request(app)
-      .get('/testdoc?query={"data.number":2}&limit=2&page=1')
+      .get('/testdoc?query={"data.number":2}&limit=2&page=1&pageMeta=1')
       .set('x-access-token', token)
       .expect(200)
     expect(res.body.itemsTotal).to.equal(1)

--- a/test/test.js
+++ b/test/test.js
@@ -47,14 +47,18 @@ describe('General Tests:', () => {
   })
 
   it('returns collections', async function () {
+    const token = await testutils.getUserWithPermissions(api, ['collection: view'])
     await request(app)
       .get('/collection')
+      .set('x-access-token', token)
       .expect(200)
   })
 
   it('Sets headers', async function () {
+    const token = await testutils.getUserWithPermissions(api, ['collection: view'])
     const res = await request(app)
       .get('/collection')
+      .set('x-access-token', token)
       .expect(200)
     expect(res.headers).to.have.property('x-request-id')
     expect(res.headers['x-request-id']).to.have.length(12)

--- a/util.js
+++ b/util.js
@@ -389,6 +389,21 @@ exports.createPagination = function createPagination (data, page, limit) {
   return pagination
 }
 
+exports.createPagePagination = function createPagePagination (pageData, page, pageItems, totalItems) {
+  const pages = totalItems >= 0 ? Math.ceil(totalItems / pageItems) : undefined
+  page = parseInt(page)
+  page = page > pages ? pages + 1 : page
+  return {
+    data: pageData,
+    page: page > pages ? pages + 1 : page,
+    itemsPerPage: pageItems,
+    itemsTotal: totalItems,
+    pages,
+    pageNext: page < pages ? page + 1 : undefined,
+    pagePrev: page - 1 > 0 ? page - 1 : undefined,
+  }
+}
+
 exports.getDatabaseOffset = function getDatabaseOffset(page, itemsPerPage) {
   return (page - 1) * itemsPerPage
 }

--- a/util.js
+++ b/util.js
@@ -388,3 +388,7 @@ exports.createPagination = function createPagination (data, page, limit) {
   pagination.data = data.splice((pagination.page - 1) * limit, limit)
   return pagination
 }
+
+exports.getDatabaseOffset = function getDatabaseOffset(page, itemsPerPage) {
+  return (page - 1) * itemsPerPage
+}


### PR DESCRIPTION
Resolves https://github.com/thomas4019/expressa/issues/169

When a paged get request comes in, previously expressa would retrieve all the matching documents from the database, and then extract the portion applicable to the page requested. This can potentially result in large amounts of data being returned to the node layer when only a portion is required.

This PR fixes that by converting `page` and `pageitems` into the database terms `limit` and `offset`. This way only the specific portion of results is read from the db and returned to the node layer. 

Using `offset` is not the most efficient option as it is slow depending on how large the offset is. However it was the easiest to implement, and since we are most concerned about lower offsets ie page 1 this solution is adequate for now. From my tests on 2000 records it resulted in a up to 4x speed increase on lower offsets, larger offsets were slower but still always faster than previous solution. Memory consumption is quaranteed to be lower too.

The new approach involves performing an additional `count` request to the database. I was under the impression this would incur a cost so made allowances for users choosing to omit the `count` request and sacrifice additional page information with the `&pagemetadisable` url param. However i did not witness any noticeable difference. I have left it in because this may change depending on how the database is accessed ie on a different server. So the choice will be up to the user