### PR TITLE
Precompressed Gzip

### DIFF
--- a/modules/admin/build/webpack.prod.conf.js
+++ b/modules/admin/build/webpack.prod.conf.js
@@ -131,13 +131,15 @@ if (config.build.productionGzip) {
 
   webpackConfig.plugins.push(
     new CompressionWebpackPlugin({
-      asset: '[path].gz[query]',
+      filename: '[path][base].gz',
       algorithm: 'gzip',
       test: new RegExp(
         '\\.(' + config.build.productionGzipExtensions.join('|') + ')$'
       ),
-      threshold: 10240,
-      minRatio: 0.8
+      compressionOptions: {
+        level: 9,
+      },
+      minRatio: Infinity,
     })
   )
 }

--- a/modules/admin/config/index.js
+++ b/modules/admin/config/index.js
@@ -71,8 +71,8 @@ module.exports = {
     // Surge or Netlify already gzip all static assets for you.
     // Before setting to `true`, make sure to:
     // npm install --save-dev compression-webpack-plugin
-    productionGzip: false,
-    productionGzipExtensions: ['js', 'css'],
+    productionGzip: true,
+    productionGzipExtensions: ['json','js','js.map','css','html','svg','xml','txt'],
 
     // Run the build command with an extra argument to
     // View the bundle analyzer report after build finishes:

--- a/modules/admin/package.json
+++ b/modules/admin/package.json
@@ -47,6 +47,7 @@
     "babel-preset-env": "1.7.0",
     "babel-preset-stage-2": "6.24.1",
     "chalk": "2.4.1",
+    "compression-webpack-plugin": "^6.1.1",
     "copy-webpack-plugin": "^5.1.0",
     "css-loader": "1.0.0",
     "eslint": "^7.0.0",


### PR DESCRIPTION
Enable creation of gzipped files during build time. 

Useful so webservers dont have to create gzip on the fly and utilize cpu - requires webserver configuration to work though