### PR TITLE
Token Expire on Password Change

### DIFF
--- a/auth/index.js
+++ b/auth/index.js
@@ -32,7 +32,7 @@ exports.middleware = async function authMiddleware(req, res, next) {
     } catch (e) {
       throw new util.ApiError(404, 'User no longer exists')
     }
-    if (user.meta.updated_password !== payload.timestamp) {
+    if (user.meta.password_last_updated_at !== payload.timestamp) {
       req.uerror = 'new token required'
     }
     else {

--- a/auth/index.js
+++ b/auth/index.js
@@ -33,7 +33,7 @@ exports.middleware = async function authMiddleware(req, res, next) {
       throw new util.ApiError(404, 'User no longer exists')
     }
     if (user.meta.password_last_updated_at !== payload.timestamp) {
-      req.uerror = 'new token required'
+      req.uerror = 'expired token'
     }
     else {
       req.uid = payload._id

--- a/auth/index.js
+++ b/auth/index.js
@@ -32,7 +32,7 @@ exports.middleware = async function authMiddleware(req, res, next) {
     } catch (e) {
       throw new util.ApiError(404, 'User no longer exists')
     }
-    if (user.meta.password_last_updated_at !== payload.timestamp) {
+    if (req.getSetting('jwt_expire_on_password_change') && user.meta.password_last_updated_at !== payload.timestamp) {
       req.uerror = 'expired token'
     }
     else {

--- a/auth/index.js
+++ b/auth/index.js
@@ -1,5 +1,6 @@
 const bcrypt = require('bcryptjs')
 const handler = require('./jwt')
+const util = require('../util')
 
 exports.createHash = function (password) {
   const salt = bcrypt.genSaltSync(10)
@@ -13,19 +14,32 @@ exports.isValidPassword = function (password, hashedPassword) {
 exports.doLogin = handler.doLogin
 
 exports.middleware = async function authMiddleware(req, res, next) {
+  req.query = req.query || {}
+  const token = req.query['token'] || req.headers['x-access-token']
+  delete req.query['token']
+  delete req.headers['x-access-token']
+  let payload
   try {
-    req.query = req.query || {}
-    const token = req.query['token'] || req.headers['x-access-token']
-    delete req.query['token']
-    delete req.headers['x-access-token']
-    const user = await handler.isLoggedIn(token, req.getSetting('jwt_secret'))
-    if (user) {
-      req.uid = user._id
-      req.ucollection = user.collection
-    }
+    payload = await handler.isLoggedIn(token, req.getSetting('jwt_secret'))
   }
   catch(e) {
     req.uerror = e.message === 'jwt expired' ? 'expired token' : 'jwt error'
+  }
+  if (payload) {
+    let user
+    try {
+      user = await req.db[payload.collection].get(payload._id)
+    } catch (e) {
+      throw new util.ApiError(404, 'User no longer exists')
+    }
+    if (user.meta.updated_password !== payload.timestamp) {
+      req.uerror = 'new token required'
+    }
+    else {
+      req.uid = payload._id
+      req.ucollection = payload.collection
+      req.user = user
+    }
   }
   next()
 }

--- a/auth/jwt.js
+++ b/auth/jwt.js
@@ -4,13 +4,14 @@ const util = require('../util')
 
 // User document already validated, created, and saved to database
 // The id of that document is given.
-exports.doLogin = function (id, collection, jwt_secret, jwt_options = {}) {
+exports.doLogin = function (id, collection, timestamp, jwt_secret, jwt_options = {}) {
   if (!jwt_secret) {
     throw new util.ApiError(500, 'missing jwt_secret')
   }
   const token = jwt.sign({
     _id: id,
-    collection
+    collection,
+    timestamp,
   }, jwt_secret, jwt_options)
   return {
     token: token,

--- a/auth/jwt.js
+++ b/auth/jwt.js
@@ -4,7 +4,7 @@ const util = require('../util')
 
 // User document already validated, created, and saved to database
 // The id of that document is given.
-exports.doLogin = function (id, collection, timestamp, jwt_secret, jwt_options = {}) {
+exports.doLogin = function ({ id, collection, timestamp, jwt_secret, jwt_options = {} }) {
   if (!jwt_secret) {
     throw new util.ApiError(500, 'missing jwt_secret')
   }

--- a/controllers/users.js
+++ b/controllers/users.js
@@ -22,7 +22,13 @@ exports.login = async (req, collection) => {
     throw new util.ApiError(401, 'Incorrect password')
   }
   const jwt_options = req.settings.jwt_expires_in ? { expiresIn: req.settings.jwt_expires_in } : {}
-  const payload = auth.doLogin(user._id, collection, user.meta.password_last_updated_at, req.getSetting('jwt_secret'), jwt_options)
+  const payload = auth.doLogin({
+    id: user._id,
+    collection,
+    timestamp: user.meta.password_last_updated_at,
+    jwt_secret: req.getSetting('jwt_secret'),
+    jwt_options
+  })
   req.uid = user._id
   req.ucollection = collection
   req.user = user

--- a/controllers/users.js
+++ b/controllers/users.js
@@ -22,9 +22,10 @@ exports.login = async (req, collection) => {
     throw new util.ApiError(401, 'Incorrect password')
   }
   const jwt_options = req.settings.jwt_expires_in ? { expiresIn: req.settings.jwt_expires_in } : {}
-  const payload = auth.doLogin(user._id, collection, req.getSetting('jwt_secret'), jwt_options)
+  const payload = auth.doLogin(user._id, collection, user.meta.updated_password, req.getSetting('jwt_secret'), jwt_options)
   req.uid = user._id
   req.ucollection = collection
+  req.user = user
   await permissions.addRolePermissionsAsync(req)
   payload.canUseAdmin = req.hasPermission('login to admin')
   return payload

--- a/controllers/users.js
+++ b/controllers/users.js
@@ -22,7 +22,7 @@ exports.login = async (req, collection) => {
     throw new util.ApiError(401, 'Incorrect password')
   }
   const jwt_options = req.settings.jwt_expires_in ? { expiresIn: req.settings.jwt_expires_in } : {}
-  const payload = auth.doLogin(user._id, collection, user.meta.updated_password, req.getSetting('jwt_secret'), jwt_options)
+  const payload = auth.doLogin(user._id, collection, user.meta.password_last_updated_at, req.getSetting('jwt_secret'), jwt_options)
   req.uid = user._id
   req.ucollection = collection
   req.user = user

--- a/listeners_users.js
+++ b/listeners_users.js
@@ -16,6 +16,7 @@ module.exports = async function(api) {
     if (data.password && data.password.length !== 60 && data.password[0] !== '$') {
       debug('hashing and replacing password in the user document.')
       data.password = auth.createHash(data.password)
+      data.meta.updated_password = new Date().toISOString()
     }
   })
 

--- a/listeners_users.js
+++ b/listeners_users.js
@@ -16,7 +16,7 @@ module.exports = async function(api) {
     if (data.password && data.password.length !== 60 && data.password[0] !== '$') {
       debug('hashing and replacing password in the user document.')
       data.password = auth.createHash(data.password)
-      data.meta.updated_password = new Date().toISOString()
+      data.meta.password_last_updated_at = new Date().toISOString()
     }
   })
 

--- a/middleware/permissions.js
+++ b/middleware/permissions.js
@@ -35,13 +35,7 @@ module.exports.addRolePermissionsAsync = async function addRolePermissionsMiddle
   let roles = ['Anonymous']
   const isAuthenticatedRole = await doesAuthenticatedRoleExist(req)
   if (req.uid) {
-    try {
-      const user = await req.db[req.ucollection].get(req.uid)
-      req.user = user
-      roles = (user.roles || []).concat(isAuthenticatedRole ? ['Authenticated'] : [])
-    } catch (e) {
-      throw new util.ApiError(404, 'User no longer exists')
-    }
+    roles = (req.user.roles || []).concat(isAuthenticatedRole ? ['Authenticated'] : [])
   } else {
     req.user = {}
   }

--- a/modules/core/core.js
+++ b/modules/core/core.js
@@ -13,6 +13,11 @@ exports.settingSchema = {
     type: 'string',
     description: 'JWT expires after - expressed in seconds or a string describing a time span eg 60, "2 days", "10h", "7d", if undefined tokens wont expire'
   },
+  jwt_expire_on_password_change: {
+    description: 'Whether to expire jwt on password change. Defaults to true',
+    type: 'boolean',
+    default: true,
+  },
   postgresql_uri: {
     type: 'string',
     description: 'The full path to your postgres database. E.g. postgres://username:password@host/db'

--- a/test/0-install.js
+++ b/test/0-install.js
@@ -24,6 +24,7 @@ describe('install flow', function () {
         modules: ['collections', 'core', 'logging', 'permissions'],
         settings: {
           jwt_secret: 'testing 123',
+          jwt_expire_on_password_change: true,
           mongodb_uri: 'mongodb://localhost:27017/test',
           postgresql_uri: 'postgresql://postgres:expressa@localhost/pgtest',
           enforce_permissions: true,

--- a/test/users.js
+++ b/test/users.js
@@ -83,7 +83,7 @@ describe('user functionality', function () {
       .expect(404)
 
     expect(res.body.error).to.exist
-    expect(res.body.tokenError).to.equal('new token required')
+    expect(res.body.tokenError).to.equal('expired token')
 
     const res2 = await request(app)
       .post('/users/login')

--- a/util.js
+++ b/util.js
@@ -1,5 +1,4 @@
 const randomstring = require('randomstring')
-const jwt = require('jsonwebtoken')
 const {v4} = require('uuid')
 const debug = require('debug')('expressa')
 const crypto = require('crypto')
@@ -184,8 +183,8 @@ exports.getUserWithPermissions = async function (api, permissions) {
   })
   const result = await api.db.users.create(user)
   user._id = result
-  const token = jwt.sign(user, api.settings.jwt_secret, {})
-  return token
+  const payload = api.util.doLogin(user._id, 'users', user.meta.updated_password, api.settings.jwt_secret, {})
+  return payload.token
 }
 
 const severities = ['critical', 'error', 'warning', 'notice', 'info', 'debug']

--- a/util.js
+++ b/util.js
@@ -189,7 +189,12 @@ exports.getUserWithPermissions = async function (api, permissions) {
   })
   const result = await api.db.users.create(user)
   user._id = result
-  const payload = api.util.doLogin(user._id, 'users', user.meta.password_last_updated_at, api.settings.jwt_secret, {})
+  const payload = api.util.doLogin({
+    id: user._id,
+    collection: 'users',
+    timestamp: user.meta.password_last_updated_at,
+    jwt_secret: api.settings.jwt_secret,
+  })
   return payload.token
 }
 

--- a/util.js
+++ b/util.js
@@ -180,7 +180,7 @@ exports.getUserWithPermissions = async function (api, permissions) {
     meta: {
       created: now,
       updated: now,
-      updated_password: now,
+      password_last_updated_at: now,
     }
   }
   await api.db.role.cache.create({
@@ -189,7 +189,7 @@ exports.getUserWithPermissions = async function (api, permissions) {
   })
   const result = await api.db.users.create(user)
   user._id = result
-  const payload = api.util.doLogin(user._id, 'users', user.meta.updated_password, api.settings.jwt_secret, {})
+  const payload = api.util.doLogin(user._id, 'users', user.meta.password_last_updated_at, api.settings.jwt_secret, {})
   return payload.token
 }
 

--- a/util.js
+++ b/util.js
@@ -171,11 +171,17 @@ exports.getUserWithPermissions = async function (api, permissions) {
   })
   const randId = randomstring.generate(12)
   const roleName = 'role' + randId
+  const now = new Date().toISOString()
   const user = {
     email: 'test' + randId + '@example.com',
     password: '123',
     collection: 'users',
-    roles: [roleName]
+    roles: [roleName],
+    meta: {
+      created: now,
+      updated: now,
+      updated_password: now,
+    }
   }
   await api.db.role.cache.create({
     _id: roleName,


### PR DESCRIPTION
Attempt to fix #184 

This is one way to resolve this issue. Store the timestamp of when the password was last updated in the token. This way, when password is changed, old tokens will no longer be valid, and those users will need to log in again. This includes logged in user.

Another way is to store session information in a collection. Im not opposed to this but figured it was a more honerous solution which could also be exploited if not careful. My initial solution seems simpler but possibly less robust.

Im keen to hear your thoughts @thomas4019 ?
