### PR TITLE
Feature/request log tweak

### DIFF
--- a/auth/index.js
+++ b/auth/index.js
@@ -25,7 +25,7 @@ exports.middleware = async function authMiddleware(req, res, next) {
     }
   }
   catch(e) {
-    req.uerror = e.message === 'jwt expired' ? 'expired token' : 'jwt error'
+    req.uerror = e.message
   }
   next()
 }

--- a/index.js
+++ b/index.js
@@ -93,7 +93,8 @@ function ph (requestHandler) {
       }
       req.returnedError = err
       res.status(err.status).send({
-        error: err.result || err.message || err, tokenError: req.uerror
+        error: err.result || err.message || err,
+        tokenError: req.uerror ?  req.uerror === 'jwt expired' ? 'expired token' : 'jwt error' : undefined
       })
     }
   }

--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ function ph (requestHandler) {
       req.returnedError = err
       res.status(err.status).send({
         error: err.result || err.message || err,
-        tokenError: req.uerror ?  req.uerror === 'jwt expired' ? 'expired token' : 'jwt error' : undefined
+        tokenError: req.uerror ?  (req.uerror === 'jwt expired' ? 'expired token' : 'jwt error') : undefined
       })
     }
   }

--- a/modules/admin/src/views/ViewRequest.vue
+++ b/modules/admin/src/views/ViewRequest.vue
@@ -8,12 +8,14 @@
       <dl>
         <dt>Request Time</dt>
         <dd>{{ log.meta.created }}</dd>
+        <dt>User</dt>
+        <dd>{{ log.user }}</dd>
+        <dt>User Collection</dt>
+        <dd>{{ log.user_collection }}</dd>
         <dt>IP</dt>
         <dd>{{ req.ip }}</dd>
-        <dt>Access token</dt>
-        <dd>{{ req.headers.x-access-token }}</dd>
         <dt>User-Agent</dt>
-        <dd>{{ req.headers.user-agent }}</dd>
+        <dd>{{ req.headers['user-agent'] }}</dd>
         <dt>Referrer</dt>
         <dd>{{ req.headers.referer }}</dd>
         <dt>Origin</dt>
@@ -34,6 +36,8 @@
         <dd>{{ res.headers['content-length'] }} bytes</dd>
         <dt>Message</dt>
         <dd>{{ res.message }}</dd>
+        <dt>Token Message</dt>
+        <dd>{{ res.tokenMessage }}</dd>
       </dl>
     </div>
   </div>

--- a/modules/logging/logging.js
+++ b/modules/logging/logging.js
@@ -31,6 +31,9 @@ exports.collections = [{
       user: {
         type: 'string'
       },
+      user_collection: {
+        type: 'string'
+      },
       req: {
         type: 'object',
         properties: {

--- a/util.js
+++ b/util.js
@@ -211,8 +211,6 @@ function filterHeaders(req) {
     'user-agent': headers['user-agent'],
     origin: headers['origin'],
     referer: headers['referer'],
-    'x-access-token': req.headers['x-access-token'] ?
-      req.headers['x-access-token'].substring(0, 8) + '...' : ''
   }
 }
 

--- a/util.js
+++ b/util.js
@@ -218,7 +218,8 @@ exports.createLogEntry = function (req, res) {
   const severity = exports.getLogSeverity(res.statusCode)
   return {
     severity: severity,
-    user: req.user ? req.user._id : undefined,
+    user: req.uid,
+    user_collection: req.ucollection,
     url: decodeURI(req.originalUrl || req.url),
     method: req.method,
     referer: req.headers['referer'],

--- a/util.js
+++ b/util.js
@@ -232,6 +232,7 @@ exports.createLogEntry = function (req, res) {
       requestId: res.getHeader('x-request-id'),
       headers: res.getHeaders(),
       message: req.returnedError ? req.returnedError.result || req.returnedError.message : undefined,
+      tokenMessage: req.uerror,
     },
     meta: {
       created: new Date().toISOString(),

--- a/util.js
+++ b/util.js
@@ -230,7 +230,7 @@ exports.createLogEntry = function (req, res) {
       statusCode: res.statusCode,
       requestId: res.getHeader('x-request-id'),
       headers: res.getHeaders(),
-      message: req.returnedError ? req.returnedError.message : undefined,
+      message: req.returnedError ? req.returnedError.result || req.returnedError.message : undefined,
     },
     meta: {
       created: new Date().toISOString(),


### PR DESCRIPTION
Small tweaks to improve requeslog information and how its displayed on admin site

1. Fix certain properties displaying as `NaN`
2. Remove access token from display since it gets stripped off request so will always be undefined
3. Surface `User` and `User Collection` on admin so requests can be easilly traced to user
4. Include `tokenError` on request log
5. Refactor `uerror` so obfuscation happens on response send so the detail is stored in the log