### PR TITLE
Fix bugs on ENDPOINTS page

### DIFF
--- a/listeners.js
+++ b/listeners.js
@@ -36,28 +36,34 @@ module.exports = function (api) {
 
   api.addCollectionListener('get', 'schemas', function addMetaToSchema (req, collection, data) {
     const schema = data.schema
-    schema.properties.meta = {
-      type: 'object',
-      propertyOrder: 2000,
-      properties: {
-        created: {
-          type: 'string'
-        },
-        updated: {
-          type: 'string'
+    if (!schema.properties.meta) {
+      schema.properties.meta = {
+        type: 'object',
+        properties: {
+          created: {
+            type: 'string'
+          },
+          updated: {
+            type: 'string'
+          }
         }
       }
     }
+    if (schema.properties.meta.propertyOrder === undefined) {
+      schema.properties.meta.propertyOrder =  2000
+    }
     if (data.documentsHaveOwners) {
-      schema.properties.meta.properties.owner = {
-        type: 'string',
-        links: [
-          {
-            rel: '» view owner user',
-            href: '/admin/#/edit/users/{{self}}',
-            class: 'comment-link'
-          }
-        ]
+      if (!schema.properties.meta.properties.owner) {
+        schema.properties.meta.properties.owner = {
+          type: 'string',
+          links: [
+            {
+              rel: '» view owner user',
+              href: '/admin/#/edit/users/{{self}}',
+              class: 'comment-link'
+            }
+          ]
+        }
       }
     }
   })

--- a/modules/admin/src/views/Endpoints.vue
+++ b/modules/admin/src/views/Endpoints.vue
@@ -117,15 +117,13 @@
               </el-checkbox>
             </div>
 
-            <template>
-              <router-link v-if="i === 0 && collectionName !== 'requestlog'" :to="'/edit/'+collectionName+'/'+scope.row._id">
-                {{ getPath(scope.row, name) }}
-              </router-link>
-              <router-link v-if="i === 0 && collectionName === 'requestlog'" :to="'/dev/viewrequest/'+scope.row._id">
-                {{ getPath(scope.row, name) }}
-              </router-link>
-              <span v-if="i !== 0">{{ getPath(scope.row, name) }}</span>
-            </template>
+            <router-link v-if="i === 0 && collectionName !== 'requestlog'" :to="'/edit/'+collectionName+'/'+scope.row._id">
+              {{ getPath(scope.row, name) }}
+            </router-link>
+            <router-link v-if="i === 0 && collectionName === 'requestlog'" :to="'/dev/viewrequest/'+scope.row._id">
+              {{ getPath(scope.row, name) }}
+            </router-link>
+            <span v-if="i !== 0">{{ getPath(scope.row, name) }}</span>
           </div>
         </template>
       </el-table-column>

--- a/modules/admin/src/views/Endpoints.vue
+++ b/modules/admin/src/views/Endpoints.vue
@@ -183,7 +183,7 @@ export default {
       }
 
       const url = this.customParams ? `/${this.apiSuffix}?${this.customParams}` : `/${this.apiSuffix}`
-      const info = (await request({ url, params })).data
+      const info = (await request({ url, params, baseURL: this.apiBaseUrl })).data
       this.count = info.itemsTotal
       this.data = this.applyCustomColumnFilter(info.data)
 

--- a/modules/admin/src/views/Endpoints.vue
+++ b/modules/admin/src/views/Endpoints.vue
@@ -181,7 +181,9 @@ export default {
         ...this.allFilters,
         query: undefined
       }
-      const info = (await request({ url: `/${this.apiSuffix}?${this.customParams}`, params })).data
+
+      const url = this.customParams ? `/${this.apiSuffix}?${this.customParams}` : `/${this.apiSuffix}`
+      const info = (await request({ url, params })).data
       this.count = info.itemsTotal
       this.data = this.applyCustomColumnFilter(info.data)
 

--- a/modules/admin/src/views/Endpoints.vue
+++ b/modules/admin/src/views/Endpoints.vue
@@ -170,6 +170,11 @@ export default {
   },
   methods: {
     async update() {
+      // Removes leading slash if any
+      while (this.apiSuffix.charAt(0) === '/') {
+        this.apiSuffix = this.apiSuffix.substring(1)
+      }
+
       if (!this.apiSuffix) {
         return
       }

--- a/modules/admin/src/views/Endpoints.vue
+++ b/modules/admin/src/views/Endpoints.vue
@@ -6,7 +6,7 @@
 
         <div class="d-flex align-items-center mb-2">
           <el-input v-model="apiBaseUrl" placeholder="key" />
-          <el-input v-model="apiSuffix" placeholder="races" />
+          <el-input v-model="apiSuffix" />
         </div>
 
         Params

--- a/modules/admin/src/views/Endpoints.vue
+++ b/modules/admin/src/views/Endpoints.vue
@@ -198,7 +198,7 @@ export default {
           ])
         }, []))
 
-        this.selectedColumns = ['_id']
+        this.selectedColumns = columns.slice(0, 5)
         this.allPossibleColumns = columns
       }
     },

--- a/modules/admin/src/views/Endpoints.vue
+++ b/modules/admin/src/views/Endpoints.vue
@@ -164,6 +164,7 @@ export default {
   mixins: [ListDocuments2],
   data() {
     return {
+      lastEndpoint: '',
       apiBaseUrl: request.defaults.baseURL,
       apiSuffix: '',
     }
@@ -179,7 +180,14 @@ export default {
         return
       }
 
-      // Fetch and Set table data
+      const currentEndpoint = `${this.apiBaseUrl}/${this.apiSuffix}`
+      const isDifferentEndpoint = currentEndpoint !== this.lastEndpoint
+
+      if (isDifferentEndpoint) {
+        this.lastEndpoint = currentEndpoint
+        this.resetTable()
+      }
+
       const params = {
         page: this.page,
         limit: this.pageSize,

--- a/modules/admin/src/views/ListDocuments2.vue
+++ b/modules/admin/src/views/ListDocuments2.vue
@@ -160,6 +160,7 @@ import saveAs from 'file-saver'
 import objectPath from 'object-path'
 
 const pageSizes = [25, 50, 100, 500]
+const defaultOrderBy = { order: null, prop: null }
 
 export default {
   name: 'ListDocuments',
@@ -196,7 +197,7 @@ export default {
     pageSize: pageSizes[0],
     isFiltersVisible: true,
     sortableFieldTypes: ['number', 'string', 'boolean'],
-    orderBy: { order: null, prop: null },
+    orderBy: { ...defaultOrderBy },
     selectedColumns: [],
     allPossibleColumns: [],
     params: [
@@ -414,18 +415,23 @@ export default {
       return this.exactSearches[fieldName] ? searchKeyword : regexQuery
     },
     resetTable() {
-      // Reset Filters
-      this.exactSearches = {}
-      this.searchFilters = {}
-      this.selectedColumns = []
-
-      // Reset pagination
-      this.page = 0
-      this.pageSize = pageSizes[0]
+      this.resetFilters()
+      this.resetPagination()
 
       // Reset table data
       this.data = []
       this.count = 0
+    },
+    resetFilters() {
+      this.exactSearches = {}
+      this.searchFilters = {}
+      this.selectedColumns = []
+      this.allPossibleColumns = []
+    },
+    resetPagination() {
+      this.page = 1
+      this.pageSize = pageSizes[0]
+      this.orderBy = defaultOrderBy
     },
     handleParamKeyChange(index) {
       const key = this.params[index].key

--- a/modules/admin/src/views/ListDocuments2.vue
+++ b/modules/admin/src/views/ListDocuments2.vue
@@ -263,22 +263,9 @@ export default {
     },
     customParams() {
       return this.params
-        .filter(param => param.isEnabled)
-        .map(param => {
-          if (param.key && param.value) {
-            return `${param.key}=${param.value}`
-          }
-
-          if (param.key) {
-            return param.key
-          }
-
-          if (param.value) {
-            return `=${param.value}`
-          }
-
-          return ''
-        }).join('&')
+        .filter(param => param.isEnabled && param.key)
+        .map(param => `${param.key}=${param.value || ''}`)
+        .join('&')
     },
   },
   watch: {

--- a/modules/admin/src/views/ListDocuments2.vue
+++ b/modules/admin/src/views/ListDocuments2.vue
@@ -234,7 +234,7 @@ export default {
       }, {})
     },
     allFilters() {
-      let orderby = '{"meta.created":-1}'
+      let orderby
 
       if (!!this.orderBy.prop && !!this.orderBy.order) {
         const propName = this.orderBy.prop
@@ -265,7 +265,7 @@ export default {
       return this.params
         .filter(param => param.isEnabled && param.key)
         .map(param => `${param.key}=${param.value || ''}`)
-        .join('&')
+        .join('&') || ''
     },
   },
   watch: {
@@ -310,7 +310,8 @@ export default {
 
       // Fetch and Set table data
       const params = { ...this.allFilters }
-      const info = (await request({ url: `/${this.collectionName}/?${this.customParams}`, params })).data
+      const url = this.customParams ? `/${this.collectionName}/?${this.customParams}` : `/${this.collectionName}`
+      const info = (await request({ url, params })).data
       this.count = info.itemsTotal
       this.data = this.applyCustomColumnFilter(info.data)
     },


### PR DESCRIPTION
Fixed the following bugs on endpoints page.
- When quering an endpoint and no parameters everything works fine. Now, add parameter race_event_id with any value and notice error, looks like the url construction contains && resulting in an empty parameter.
- orderby  should not have default values.
- Fields should show the first 5 (not default to _id).
- Do not default endpoint placeholder to race ( the placeholder should be empty).
- In the path field, put /race  (with the slash) and see the request URL going crazy.
- fix table not resetting when endpoint is updated