### PR TITLE
Fix/endpoints page

### DIFF
--- a/modules/admin/src/views/Endpoints.vue
+++ b/modules/admin/src/views/Endpoints.vue
@@ -117,13 +117,7 @@
               </el-checkbox>
             </div>
 
-            <router-link v-if="i === 0 && collectionName !== 'requestlog'" :to="'/edit/'+collectionName+'/'+scope.row._id">
-              {{ getPath(scope.row, name) }}
-            </router-link>
-            <router-link v-if="i === 0 && collectionName === 'requestlog'" :to="'/dev/viewrequest/'+scope.row._id">
-              {{ getPath(scope.row, name) }}
-            </router-link>
-            <span v-if="i !== 0">{{ getPath(scope.row, name) }}</span>
+            <span>{{ getPath(scope.row, name) }}</span>
           </div>
         </template>
       </el-table-column>
@@ -196,7 +190,29 @@ export default {
       }
 
       const url = this.customParams ? `/${this.apiSuffix}?${this.customParams}` : `/${this.apiSuffix}`
-      const info = (await request({ url, params, baseURL: this.apiBaseUrl })).data
+      let info = (await request({ url, params, baseURL: this.apiBaseUrl })).data
+
+      const isNotPaged = !info.page && !info.itemsTotal
+
+      if (isNotPaged) {
+        if (!Array.isArray(info)) {
+          if (typeof info !== 'object') {
+            // If response is primitive type
+            info = [{
+              result: info
+            }]
+          } else {
+            // If response is an object
+            info = [info]
+          }
+        }
+
+        info = {
+          data: info,
+          itemsTotal: 1
+        }
+      }
+
       this.count = info.itemsTotal
       this.data = this.applyCustomColumnFilter(info.data)
 

--- a/modules/admin/src/views/ListDocuments2.vue
+++ b/modules/admin/src/views/ListDocuments2.vue
@@ -205,6 +205,9 @@ export default {
     ]
   }),
   computed: {
+    isEndpointsPage() {
+      return this.$options.name === 'Endpoints'
+    },
     tableRows() {
       if (!this.isFiltersVisible) {
         return this.data
@@ -235,7 +238,7 @@ export default {
       }, {})
     },
     allFilters() {
-      let orderby
+      let orderby = this.isEndpointsPage ? undefined : '{"meta.created":-1}'
 
       if (!!this.orderBy.prop && !!this.orderBy.order) {
         const propName = this.orderBy.prop


### PR DESCRIPTION
Fix a few bugs with the endpoints page:
1. Order by should have '{"meta.created":-1}'  by default on all Data pages.
2. Also show some data even if not paginated or not array