### PR TITLE
fix: use objectPath.get to get the value

### DIFF
--- a/modules/admin/src/views/ListDocuments2.vue
+++ b/modules/admin/src/views/ListDocuments2.vue
@@ -361,7 +361,7 @@ export default {
             return true
           }
 
-          const stringified = row[fieldName].toString()
+          const stringified = String(objectPath.get(row, fieldName) || '')
 
           if (this.exactSearches[fieldName]) {
             return stringified === searchKeyword


### PR DESCRIPTION
Use objectPath.get to get the value of a cell inside `applyCustomColumnFilter`. The name of the fields can be `fieldname.childFieldname` so standard way might not always work.