### PR TITLE
Owner Updates

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,7 +20,7 @@
         "xdescribe": true
     },
     "parserOptions": {
-        "ecmaVersion": 2018
+        "ecmaVersion": 2022
     },
     "env": {
         "es6": true,

--- a/controllers/collections.js
+++ b/controllers/collections.js
@@ -202,7 +202,9 @@ exports.updateById = async function (req) {
   const newOwnerCollection = doc.meta && doc.meta.ownerCollection
   if (owner !== newOwner || ownerCollection !== newOwnerCollection) {
     if (req.hasPermission(`${req.params.collection}: modify owner`)) {
+      if (owner) {
         await validateDocumentOwner(req, doc)
+      }
     } else {
       debug('attempting to change document owner.')
       doc.meta.owner = owner

--- a/controllers/collections.js
+++ b/controllers/collections.js
@@ -169,8 +169,12 @@ exports.updateById = async function (req) {
   util.mongoUpdate(doc, modifier)
   const newOwner = doc.meta && doc.meta.owner
   if (owner !== newOwner) {
+    if (req.hasPermission(`${req.params.collection}: modify owner`)) {
+      await validateDocumentOwner(req, doc)
+    } else {
     debug('attempting to change document owner.')
     doc.meta.owner = owner
+  }
   }
   req.body = doc
   await util.notify('put', req, req.params.collection, doc)

--- a/controllers/collections.js
+++ b/controllers/collections.js
@@ -196,10 +196,10 @@ exports.updateById = async function (req) {
 
   const doc = await req.db[req.params.collection].get(req.params.id)
   const owner = doc.meta && doc.meta.owner
-  const ownerCollection = doc.meta && doc.meta.ownerCollection
+  const ownerCollection = doc.meta && doc.meta.owner_collection
   util.mongoUpdate(doc, modifier)
   const newOwner = doc.meta && doc.meta.owner
-  const newOwnerCollection = doc.meta && doc.meta.ownerCollection
+  const newOwnerCollection = doc.meta && doc.meta.owner_collection
   if (owner !== newOwner || ownerCollection !== newOwnerCollection) {
     if (req.hasPermission(`${req.params.collection}: modify owner`)) {
       if (owner) {
@@ -208,7 +208,7 @@ exports.updateById = async function (req) {
     } else {
       debug('attempting to change document owner.')
       doc.meta.owner = owner
-      doc.meta.ownerCollection = ownerCollection
+      doc.meta.owner_collection = ownerCollection
     }
   }
   req.body = doc

--- a/controllers/collections.js
+++ b/controllers/collections.js
@@ -178,8 +178,6 @@ exports.updateById = async function (req) {
   }
   req.body = doc
   await util.notify('put', req, req.params.collection, doc)
-
-  req.body.meta.owner = newOwner
   await req.db[req.params.collection].update(req.params.id, req.body)
   await util.notify('changed', req, req.params.collection, req.body)
   if (Object.keys(req.customResponseData)) {

--- a/listeners.js
+++ b/listeners.js
@@ -55,6 +55,9 @@ module.exports = function (api) {
               class: 'comment-link'
             }
           ]
+        },
+        schema.properties.meta.properties.owner_collection = {
+          type: 'string'
         }
       }
     }

--- a/listeners.js
+++ b/listeners.js
@@ -18,19 +18,11 @@ module.exports = function (api) {
     Object.assign(req.settings, data)
   })
 
-  api.addListener(['put', 'post'], function updateMetadata (req, collection, data, { event }) {
-    data.meta = data.meta || {}
+  api.addListener(['put', 'post'], async function updateMetadata (req, collection, data, { event }) {
+    data.meta ??= {}
     data.meta.updated = new Date().toISOString()
     if (event === 'post') {
       data.meta.created = new Date().toISOString()
-      if (req.user) {
-        if (req.hasPermission('login to admin')) {
-          data.meta.owner = data.meta.owner || req.user._id
-        }
-        else {
-          data.meta.owner = req.user._id
-        }
-      }
     }
   })
 

--- a/listeners_collection_permissions.js
+++ b/listeners_collection_permissions.js
@@ -19,11 +19,8 @@ module.exports = function (api) {
 
   api.addListener(['get', 'put', 'post', 'delete'], function collectionPermissionCheck (req, collection, data, info) {
     const permission = eventToPermissionMapping[info.event]
-    const editingSelf = collection === req.ucollection && data._id === req.uid
     const editingOwnDoc = data.meta && data.meta.owner && data.meta.owner === req.uid
-    const editingOwn = ((editingSelf || editingOwnDoc) &&
-      req.hasPermission(collection + ': ' + permission + ' own'))
-    // console.log(editingOwn + ' ' + editingSelf + ' ' + editingOwnDoc);
+    const editingOwn = editingOwnDoc && req.hasPermission(collection + ': ' + permission + ' own')
     if (!editingOwn && !req.hasPermission(collection + ': ' + permission)) {
       debug(`cancelling, missing permission "${collection}: ${permission}"`)
       throw new util.ApiError(401, 'You do not have permission to perform this action.')

--- a/listeners_users.js
+++ b/listeners_users.js
@@ -56,7 +56,7 @@ module.exports = async function(api) {
   })
 
   api.addCollectionListener(['post', 'put'], loginCollections, async function userEmailLowerCase(req, collection, data) {
-    data.email = data.email.toLowerCase()
+    data.email = data.email?.toLowerCase()
   })
 
   api.addCollectionListener('post', loginCollections, async function userUniquenessCheck(req, collection, data) {
@@ -73,7 +73,7 @@ module.exports = async function(api) {
       if (!doc.schema.properties.roles.items.enum.includes(data._id)) {
         doc.schema.properties.roles.items.enum.push(data._id)
         await api.db.collection.update(coll, doc)
-        await api.notify('changed', req, coll, doc)
+        await api.notify('changed', req, 'collection', doc)
       }
     }
   })
@@ -85,7 +85,7 @@ module.exports = async function(api) {
       if (roles.includes(data._id)) {
         roles.splice(roles.indexOf(data._id), 1)
         await api.db.collection.update(coll, doc)
-        await api.notify('changed', req, coll, doc)
+        await api.notify('changed', req, 'collection', doc)
       }
     }
   })

--- a/listeners_users.js
+++ b/listeners_users.js
@@ -56,7 +56,7 @@ module.exports = async function(api) {
   })
 
   api.addCollectionListener(['post', 'put'], loginCollections, async function userEmailLowerCase(req, collection, data) {
-    data.email = data.email?.toLowerCase()
+    data.email = data.email.toLowerCase()
   })
 
   api.addCollectionListener('post', loginCollections, async function userUniquenessCheck(req, collection, data) {

--- a/listeners_validation.js
+++ b/listeners_validation.js
@@ -8,6 +8,7 @@ function addImplicitFields (schema) {
   schema['properties']['meta']['properties']['updated'] ??= { type: 'string' }
   schema['properties']['meta']['properties']['owner'] ??= { type: 'string' }
   schema['properties']['meta']['properties']['owner_collection'] ??= { type: 'string' }
+  schema['properties']['_id'] ??= { type: 'string' }
   return schema
 }
 

--- a/listeners_validation.js
+++ b/listeners_validation.js
@@ -1,16 +1,13 @@
 const util = require('./util')
 
 function addImplicitFields (schema) {
-  schema['properties'] = schema['properties'] || {}
-  schema['properties']['meta'] = schema['properties']['meta'] || { type: 'object' }
-  schema['properties']['meta']['properties'] = schema['properties']['meta']['properties'] || {}
-  schema['properties']['meta']['properties']['created'] = schema['properties']['meta']['properties']['created'] ||
-      { type: 'string' }
-  schema['properties']['meta']['properties']['updated'] = schema['properties']['meta']['properties']['updated'] ||
-      { type: 'string' }
-  schema['properties']['meta']['properties']['owner'] = schema['properties']['meta']['properties']['owner'] ||
-      { type: 'string' }
-  schema['properties']['_id'] = schema['properties']['_id'] || { type: 'string' }
+  schema['properties'] ??= {}
+  schema['properties']['meta'] ??= { type: 'object' }
+  schema['properties']['meta']['properties'] ??= {}
+  schema['properties']['meta']['properties']['created'] ??= { type: 'string' }
+  schema['properties']['meta']['properties']['updated'] ??= { type: 'string' }
+  schema['properties']['meta']['properties']['owner'] ??= { type: 'string' }
+  schema['properties']['meta']['properties']['owner_collection'] ??= { type: 'string' }
   return schema
 }
 

--- a/modules/collections/collections.js
+++ b/modules/collections/collections.js
@@ -1,9 +1,17 @@
 function getCollectionPermissions (name, hasOwner) {
-  let permissions = ['create', 'view', 'edit', 'delete'].map((action) => `${name}: ${action}`)
+  let permissions = exports.collectionPermissions(name)
   if (hasOwner) {
-    permissions = permissions.concat(['view', 'edit', 'delete'].map((action) => `${name}: ${action} own`))
+    permissions = permissions.concat(exports.collectionOwnerPermissions(name))
   }
   return permissions
+}
+
+exports.collectionPermissions = function (name) {
+  return ['create', 'view', 'edit', 'modify owner', 'delete'].map((action) => `${name}: ${action}`)
+}
+
+exports.collectionOwnerPermissions = function (name) {
+  return ['view', 'edit', 'delete'].map((action) => `${name}: ${action} own`)
 }
 
 exports.permissions = async function (app) {

--- a/modules/permissions/permissions.js
+++ b/modules/permissions/permissions.js
@@ -1,3 +1,5 @@
+const { collectionPermissions, collectionOwnerPermissions } = require('../collections/collections')
+
 exports.settingSchema = {
   enforce_permissions: {
     type: 'boolean',
@@ -56,14 +58,6 @@ exports.install = async function (app) {
 }
 
 exports.permissions = ['users: modify roles', 'login to admin']
-
-function collectionPermissions (name) {
-  return ['create', 'view', 'edit', 'delete'].map((action) => `${name}: ${action}`)
-}
-
-function collectionOwnerPermissions (name) {
-  return ['view', 'edit', 'delete'].map((action) => `${name}: ${action} own`)
-}
 
 exports.init = async function (api) {
   api.addCollectionListener(['changed'], 'collection', async function addCollectionPerms (req, collection, data) {

--- a/test/0-install.js
+++ b/test/0-install.js
@@ -63,6 +63,17 @@ describe('install flow', function () {
     expect(u.roles || []).to.include('Admin')
   })
 
+  it('can login admin account', async function() {
+    const res = await request(app)
+      .post('/users/login')
+      .send({
+        email: 'a@example.com',
+        password: '123'
+      })
+      .expect(200)
+    testutils.setAdminToken(res.body.token)
+  })
+
   it('2nd account cannot be admin account', async function() {
     await request(app)
       .post('/users/register')

--- a/test/collections.querying.js
+++ b/test/collections.querying.js
@@ -11,7 +11,7 @@ const { app, api } = testutils
  */
 describe('querying collections', function () {
   it('create doc 1', async function () {
-    const token = await util.getUserWithPermissions(api, 'testdoc: create')
+    const token = await testutils.getUserWithPermissions(api, 'testdoc: create')
     await request(app)
       .post('/testdoc')
       .set('x-access-token', token)
@@ -28,7 +28,7 @@ describe('querying collections', function () {
   })
 
   it('create doc 2', async function () {
-    const token = await util.getUserWithPermissions(api, 'testdoc: create')
+    const token = await testutils.getUserWithPermissions(api, 'testdoc: create')
     await request(app)
       .post('/testdoc')
       .set('x-access-token', token)
@@ -42,7 +42,7 @@ describe('querying collections', function () {
   })
 
   it('create doc 3', async function () {
-    const token = await util.getUserWithPermissions(api, 'testdoc: create')
+    const token = await testutils.getUserWithPermissions(api, 'testdoc: create')
     await request(app)
       .post('/testdoc')
       .set('x-access-token', token)
@@ -60,7 +60,7 @@ describe('querying collections', function () {
   let token
 
   it('read doc by id', async function () {
-    token = await util.getUserWithPermissions(api, 'testdoc: view')
+    token = await testutils.getUserWithPermissions(api, 'testdoc: view')
     const res = await request(app)
       .get('/testdoc/testid123')
       .set('x-access-token', token)
@@ -202,7 +202,7 @@ describe('querying collections', function () {
   })
 
   it('sort by deep field ascending', async function () {
-    const token = await util.getUserWithPermissions(api, 'testdoc: view')
+    const token = await testutils.getUserWithPermissions(api, 'testdoc: view')
     const res = await request(app)
       .get('/testdoc?orderby={"data.number":1}')
       .set('x-access-token', token)
@@ -214,7 +214,7 @@ describe('querying collections', function () {
   })
 
   it('sort by deep field descending', async function () {
-    const token = await util.getUserWithPermissions(api, 'testdoc: view')
+    const token = await testutils.getUserWithPermissions(api, 'testdoc: view')
     const res = await request(app)
       .get('/testdoc?orderby={"meta.created":-1}')
       .set('x-access-token', token)
@@ -226,7 +226,7 @@ describe('querying collections', function () {
   })
 
   it('project a specific field', async function () {
-    const token = await util.getUserWithPermissions(api, 'testdoc: view')
+    const token = await testutils.getUserWithPermissions(api, 'testdoc: view')
     const res = await request(app)
       .get('/testdoc?fields={"title":1}')
       .set('x-access-token', token)
@@ -237,7 +237,7 @@ describe('querying collections', function () {
   })
 
   it('project a specific field on get', async function () {
-    const token = await util.getUserWithPermissions(api, 'testdoc: view')
+    const token = await testutils.getUserWithPermissions(api, 'testdoc: view')
     const res = await request(app)
       .get('/testdoc/test1?fields={"title":1}')
       .set('x-access-token', token)
@@ -247,7 +247,7 @@ describe('querying collections', function () {
   })
 
   it('project deep fields', async function() {
-    const token = await util.getUserWithPermissions(api, 'testdoc: view')
+    const token = await testutils.getUserWithPermissions(api, 'testdoc: view')
     const res = await request(app)
       .get('/testdoc?fields={"data":1}')
       .set('x-access-token', token)

--- a/test/test.js
+++ b/test/test.js
@@ -70,7 +70,7 @@ describe('General Tests:', () => {
       res.send(req.user)
     })
 
-    const token = await util.getUserWithPermissions(api, [])
+    const token = await testutils.getUserWithPermissions(api, [])
     const res = await request(app)
       .get('/test')
       .set('x-access-token', token)

--- a/test/testutils.js
+++ b/test/testutils.js
@@ -1,6 +1,7 @@
 const fs = require('fs')
 
 const expressa = require('../')
+const request = require('supertest')
 const util = require('../util')
 
 // See https://stackoverflow.com/questions/18052762/remove-directory-which-is-not-empty
@@ -25,10 +26,61 @@ exports.api = expressa.api({
   file_storage_path: 'testdata'
 })
 const express = require('express')
+const randomstring = require('randomstring')
 exports.app = express()
 exports.app.use(exports.api)
 
-exports.getUserWithPermissions = util.getUserWithPermissions
+const tokens = {
+  admin: ''
+}
+
+exports.setAdminToken = function(token) {
+  tokens.admin = token
+}
+
+exports.getUserWithPermissions = async function(api, permissions) {
+  const service = request(exports.app)
+  if (typeof permissions === 'string') {
+    permissions = [permissions]
+  }
+  permissions = permissions || []
+  const permissionsMap = {}
+  permissions.forEach(function (permission) {
+    permissionsMap[permission] = true
+  })
+
+  const randId = randomstring.generate(12)
+  const roleName = 'role' + randId
+  const role = {
+    _id: roleName,
+    permissions: permissionsMap
+  }
+
+  const roleRes = await service.post('/role')
+    .set('x-access-token', tokens.admin)
+    .send(role)
+    .expect(200)
+
+  const user = {
+    email: 'test' + randId + '@example.com',
+    password: '123',
+  }
+  const registerRes = await service.post('/users/register')
+    .send(user)
+    .expect(200)
+
+  const updateRes = await service.post(`/users/${registerRes.body.id}/update`)
+    .send({ $push: { roles: roleName } })
+    .set('x-access-token', tokens.admin)
+    .expect(200)
+
+  const loginRes = await service.post('/users/login')
+    .send(user)
+    .expect(200)
+
+  user._id = loginRes.body.uid
+  return loginRes.body.token
+}
 exports.clone = util.clone
 exports.sleep = function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms))

--- a/test/users.js
+++ b/test/users.js
@@ -189,4 +189,59 @@ describe('user functionality', function () {
       .expect(200)
     expect(res3.body.properties.roles.items.enum).to.not.include('testrole')
   })
+
+  it('cannot change owner by default', async function () {
+    const token = await testutils.getUserWithPermissions(api, ['users: view', 'users: edit'])
+
+    const res = await request(app)
+      .get(`/users/me`)
+      .set('x-access-token', token)
+    const newUser = res.body
+
+    await request(app)
+      .post(`/users/${newUser._id}/update`)
+      .set('x-access-token', token)
+      .send({ $set: { 'meta.owner': user._id } }) // try change owner to another user
+      .expect(200) // will succeed but owner will not change
+
+    const res2 = await request(app)
+      .get(`/users/${newUser._id}`)
+      .set('x-access-token', token)
+    expect(res2.body.meta.owner).to.not.equal(user._id)
+  })
+
+  it('can change owner with correct permission', async function () {
+    const token = await testutils.getUserWithPermissions(api, ['users: view', 'users: edit', 'users: modify owner'])
+
+    const res = await request(app)
+      .get(`/users/me`)
+      .set('x-access-token', token)
+    const newUser = res.body
+
+    await request(app)
+      .post(`/users/${newUser._id}/update`)
+      .set('x-access-token', token)
+      .send({ $set: { 'meta.owner': user._id } }) // try change owner to another user
+      .expect(200)
+
+    const res2 = await request(app)
+      .get(`/users/${newUser._id}`)
+      .set('x-access-token', token)
+    expect(res2.body.meta.owner).to.equal(user._id)
+  })
+
+  it('changing to bogus owner fails', async function () {
+    const token = await testutils.getUserWithPermissions(api, ['users: view', 'users: edit', 'users: modify owner'])
+
+    const res = await request(app)
+      .get(`/users/me`)
+      .set('x-access-token', token)
+    const newUser = res.body
+
+    await request(app)
+      .post(`/users/${newUser._id}/update`)
+      .set('x-access-token', token)
+      .send({ $set: { 'meta.owner': 'owner-that-doesnt-exist' } }) // try change owner to another user
+      .expect(417)
+  })
 })

--- a/test/users.js
+++ b/test/users.js
@@ -208,6 +208,8 @@ describe('user functionality', function () {
       .get(`/users/${newUser._id}`)
       .set('x-access-token', token)
     expect(res2.body.meta.owner).to.not.equal(user._id)
+    expect(res2.body.meta.owner).to.equal(newUser._id)
+
   })
 
   it('can change owner with correct permission', async function () {
@@ -243,5 +245,67 @@ describe('user functionality', function () {
       .set('x-access-token', token)
       .send({ $set: { 'meta.owner': 'owner-that-doesnt-exist' } }) // try change owner to another user
       .expect(417)
+  })
+
+  it('cannot set owner on creation by default', async function () {
+    const token = await testutils.getUserWithPermissions(api, ['users: view', 'users: edit', 'testdoc: create', 'testdoc: view own'])
+
+    const res = await request(app)
+      .get(`/users/me`)
+      .set('x-access-token', token)
+    const newUser = res.body
+
+    const doc = {
+      title: 'Test Title',
+      meta: {
+        owner: user._id,
+        owner_collection: 'users',
+      }
+    }
+
+    const res2 = await request(app)
+      .post(`/testdoc`)
+      .set('x-access-token', token)
+      .send(doc)
+      .expect(200) // will succeed but owner will not change
+    doc._id = res2.body.id
+
+    const res3 = await request(app)
+      .get(`/testdoc/${doc._id}`)
+      .set('x-access-token', token)
+      .expect(200)
+    expect(res3.body.meta.owner).to.not.equal(user._id)
+    expect(res3.body.meta.owner).to.equal(newUser._id)
+  })
+
+  it('can set owner on creation with correct permission', async function () {
+    const token = await testutils.getUserWithPermissions(api, ['users: view', 'users: edit', 'testdoc: create', 'testdoc: view', 'testdoc: modify owner'])
+
+    const res = await request(app)
+      .get(`/users/me`)
+      .set('x-access-token', token)
+    const newUser = res.body
+
+    const doc = {
+      title: 'Test Title',
+      meta: {
+        owner: user._id,
+        owner_collection: 'users',
+      }
+    }
+
+    const res2 = await request(app)
+      .post(`/testdoc`)
+      .set('x-access-token', token)
+      .send(doc)
+      .expect(200) // will succeed but owner will not change
+    doc._id = res2.body.id
+
+    const res3 = await request(app)
+      .get(`/testdoc/${doc._id}`)
+      .set('x-access-token', token)
+      .expect(200)
+    expect(res3.body.meta.owner).to.not.equal(newUser._id)
+    expect(res3.body.meta.owner).to.equal(user._id)
   })
 })

--- a/util.js
+++ b/util.js
@@ -202,44 +202,6 @@ exports.createSecureRandomId = function() {
   return crypto.randomBytes(24).toString('hex')
 }
 
-exports.getUserWithPermissions = async function (api, permissions) {
-  if (typeof permissions === 'string') {
-    permissions = [permissions]
-  }
-  permissions = permissions || []
-  const permissionsMap = {}
-  permissions.forEach(function (permission) {
-    permissionsMap[permission] = true
-  })
-  const randId = randomstring.generate(12)
-  const roleName = 'role' + randId
-  const now = new Date().toISOString()
-  const user = {
-    email: 'test' + randId + '@example.com',
-    password: '123',
-    collection: 'users',
-    roles: [roleName],
-    meta: {
-      created: now,
-      updated: now,
-      password_last_updated_at: now,
-    }
-  }
-  await api.db.role.cache.create({
-    _id: roleName,
-    permissions: permissionsMap
-  })
-  const result = await api.db.users.create(user)
-  user._id = result
-  const payload = api.util.doLogin({
-    id: user._id,
-    collection: 'users',
-    timestamp: user.meta.password_last_updated_at,
-    jwt_secret: api.settings.jwt_secret,
-  })
-  return payload.token
-}
-
 const severities = ['critical', 'error', 'warning', 'notice', 'info', 'debug']
 exports.getLogSeverity = function (status) {
   const severity = status >= 500 ? 'error'

--- a/util.js
+++ b/util.js
@@ -381,7 +381,7 @@ exports.addIdIfMissing = function addIdIfMissing (document) {
 }
 
 exports.sortObjectKeys = function sortObjectKeys(object) {
-  if (typeof object != 'object' || object instanceof Array) { // Do not sort the array
+  if (typeof object != 'object' || object instanceof Array || !object) { // Do not sort the array
     return object
   }
   const keys = Object.keys(object)

--- a/util.js
+++ b/util.js
@@ -368,10 +368,10 @@ exports.getLoginCollections = async function(api) {
 function isValidLoginCollection(collection) {
   const name = collection._id
   if(collection.enableLogin === true) {
-    const properties = collection.schema && collection.schema.properties
-    if (properties && properties.email && properties.password && properties.roles) {
-      const required = collection.schema && collection.schema.required
-      if (required && required.includes('email') && required.includes('password')) {
+    const properties = collection.schema?.properties
+    if (properties && properties.password && properties.roles) {
+      const required = collection.schema?.required
+      if (required?.includes('password')) {
         return true
       }
       else {


### PR DESCRIPTION
Various updates to improve document owner control:

1. Added `meta` property `owner_collection` - since we added support for creating your own `user` collections this will remove any ambiguity over which collection the owner is from
2. Owner system didnt (couldnt) account for `user` collections owning a document from another `user` collection
3. Since a `user` doc may have a different owner, removed the `editingSelf` check as would allow a bypass of ownership
4. Add new permission `{collection}: modify owner` - as implies grants permission to change owner for particular collection
5. Fix setting of owner during creation. Previously logic was inconsistent and had no tests for it. The `documentHasOwners` property did not factor in at all.
6. Relax requirement for `user` collection to not require `email` to be `required` in the schema, anticipate methods other than email being used in future for user uniqueness
7. Tests added to validate above

Other Updates
1. Refactor `collectionPermissions` to come from common source, as logic was duplicated
2. Modernise javascript where I went, updated lint target to `es2022` 
3. Fixed bug where creating a new `Role`, would try but NOT add it into `roles` `enum` on`user` collections
4. Updated `getUserWithPermissions` so that user creation flows through api and listeners etc