### PR TITLE
Orderby For Paged Requests Oddity

### DIFF
--- a/controllers/collections.js
+++ b/controllers/collections.js
@@ -101,7 +101,7 @@ exports.get = async function (req) {
     }
     req.query.pageitems = parseInt(req.query.pageitems) || parseInt(req.query.limit) || 10
     req.query.offset = util.getDatabaseOffset(req.query.page, req.query.pageitems)
-    req.query.orderby = req.query.orderby || util.normalizeOrderBy({ 'meta.created': 1 }) // paging requires orderby to ensure consistent results with offset and limit
+    req.query.orderby = util.orderByForPagedRequests(req.query.orderby)
     delete req.query.limit
     delete req.query.skip
     let pageData, totalItems

--- a/util.js
+++ b/util.js
@@ -185,6 +185,18 @@ exports.mongoUpdate = function(doc, update) {
   return mongoQuery(doc, {}, update)
 }
 
+// paging requires orderby to include a field that is known to be unique and constant
+// to ensure consistent results from database with offset and limit. Chosen field should
+// also represent a preferred ordering when doing final sort
+exports.orderByForPagedRequests = function(orderby, finalSortField = 'meta.created') {
+  orderby = exports.normalizeOrderBy(orderby || {})
+  const allFields = orderby.map(([field]) => field)
+  if (!allFields.includes(finalSortField)) {
+    orderby.push([finalSortField, 1])
+  }
+  return orderby
+}
+
 exports.normalizeOrderBy = function(orderby) {
   if (Array.isArray(orderby)) {
     orderby = orderby.map(function (ordering) {


### PR DESCRIPTION
When using paged requests, to ensure page results are consistently ordered no matter what the page size or number, the final sort field needs to be constant and unique. otherwise whatever orderby you have specified, if there are multiple matches the database will return them in any order and when using offset an limit this can sometimes mean the result you expect is not returned at all between pages